### PR TITLE
Relativity

### DIFF
--- a/py4DSTEM/file/readwrite/read.py
+++ b/py4DSTEM/file/readwrite/read.py
@@ -19,7 +19,6 @@
 import hyperspy.api as hs
 from .dm import dmReader
 from .empad import read_empad
-from ...process.preprocess import read_mrc_file
 from .filebrowser import FileBrowser, is_py4DSTEM_file
 from ..datastructure import DataCube
 from ..datastructure import Metadata
@@ -76,8 +75,9 @@ def read(filename, load=None):
             print("Reading an EMPAD file...")
             output = read_empad_file(filename)
         elif load == 'relativity':
+            import mrcfile
             print("Reading an IDES Relativity MRC file...")
-            output = read_mrc_file(filename)
+            output = mrcfile.mmap(filename,mode='r')
         else:
             print("Error: unknown value for parameter 'load' = {}. Returning None. See the read docstring for more info.".format(load))
             output = None

--- a/py4DSTEM/file/readwrite/read.py
+++ b/py4DSTEM/file/readwrite/read.py
@@ -19,6 +19,7 @@
 import hyperspy.api as hs
 from .dm import dmReader
 from .empad import read_empad
+from ...process.preprocess import read_mrc_file
 from .filebrowser import FileBrowser, is_py4DSTEM_file
 from ..datastructure import DataCube
 from ..datastructure import Metadata
@@ -57,6 +58,11 @@ def read(filename, load=None):
         load a dm file (.d3 or .dm4), memory mapping the datacube, using dm.py
     load = 'empad'
         load an EMPAD formatted file, using empad.py
+
+    For IDES Relativity mrc files, the output is a memory map to the "movie" which 
+    must be sliced into subframes using the relativity module in py4DTEM.process.preprocess
+    load = 'relativity'
+        load an MRC file from the IDES Relativity. See py4DSTEM.process.preprocess.relativity
     """
     if not is_py4DSTEM_file(filename):
         print("{} is not a py4DSTEM file.".format(filename))
@@ -69,6 +75,9 @@ def read(filename, load=None):
         elif load == 'empad':
             print("Reading an EMPAD file...")
             output = read_empad_file(filename)
+        elif load == 'relativity':
+            print("Reading an IDES Relativity MRC file...")
+            output = read_mrc_file(filename)
         else:
             print("Error: unknown value for parameter 'load' = {}. Returning None. See the read docstring for more info.".format(load))
             output = None

--- a/py4DSTEM/process/preprocess/__init__.py
+++ b/py4DSTEM/process/preprocess/__init__.py
@@ -1,3 +1,4 @@
 from .preprocess import *
 from .darkreference import *
 from .electroncount import *
+from .relativity import *

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -25,7 +25,7 @@ def slice_subframes(frame, x_cent, y_cent, wx=500, wy=500):
 	return stack
 
 
-def subframeAlign(testDP, xcent, ycent, wx=500, wy=500, niter=10, maxshift=80, anchorDP=0, corrPower=0.5, damping=0.5 ):
+def subframeAlign(testDP, xcent, ycent, wx=500, wy=500, niter=10, maxshift=80, anchorDP=0, corrPower=0.5, damping=1 ):
 	"""
 	Detrmine the alignment of the subframes in a Relativity frame by gradient descent. Arguments are:
 

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -1,0 +1,149 @@
+import numpy as np
+import mrcfile
+from ..utils import get_shift_hybrid
+import matplotlib.pyplot as plt
+from ipywidgets import FloatProgress
+from time import time
+from ...file.datastructure import DataCube
+
+def read_mrc_file(filename):
+	# read in an *.mrc file as an MRC memmap
+	return mrcfile.mmap(filename,mode='r')
+
+
+def slice_subframes(frame, x_cent, y_cent, wx=500, wy=500):
+	"""
+	Slice a movie frame into subframes, given the center points x_cent and y_cent (which are numpy meshgrids)
+	and the subframe width wx, wy
+	Returns a 3D stack of diffraction patterns.
+	"""
+	nDP = xcents.shape[0] * xcents.shape[1]
+	stack = np.zeros((wx,wy,nDP))
+
+	dx = np.round(wx/2).astype(int)
+	dy = np.round(wy/2).astype(int)
+
+	for Rx in range(xcents.shape[0]):
+		for Ry in range(xcents.shape[1]):
+			DPind = np.ravel_multi_index((Rx,Ry),(xcents.shape[0],xcents.shape[1]))
+			stack[:,:,DPind] = np.roll(DP,(-(xcents[Rx,Ry]-dx),-(ycents[Rx,Ry]-dy)),axis=(0,1))[:wx,:wy]
+
+	return stack
+
+
+def subframeAlign(testDP, xcent, ycent, wx=500, wy=500, niter=10, maxshift=80, anchorDP=0, corrPower=0.5, damping=0.5 ):
+	"""
+	Detrmine the alignment of the subframes in a Relativity frame by gradient descent. Arguments are:
+
+	testDP			(numpy array) a single frame from a Relativity movie, ideally with all subframes similarly illuminated
+	xcent, ycent 	(numpy meshgrids) initial guesses of the centers
+	wx,wy 			(ints) frame x- and y-sizes
+	niter			(int) number of iterations of gradient descent to optimize shifts
+	maxshift		(int) maximum allowable shift. This only triggers an error if the shifts exceed it, it doesn't constrain fitting
+	anchorDP		(int) index of the DP that should be kept static. Other positions are fitted to align subframes with this one.
+	corrPower		(float) Hybrid correlation power. Phase-y correlation works well when you have a beamstop
+	damping			(float) damps the update steps. Set to 1 for no damping (you can probably get away with no damping)
+	"""
+
+	err = np.zeros(niter)
+
+	nudgex = np.zeros_like(xcent)
+	nudgey = np.zeros_like(ycent)
+
+	anchorx,anchory = np.unravel_index(anchorDP,xcent.shape)
+
+	for iter in range(niter):
+
+		#get the stack using the current centers
+		stack = slice_subframes(testDP,xcent+nudgex,ycent+nudgey,wx,wy)
+
+		#compute the error metric
+		shifterr = np.zeros(stack.shape[2])
+		for ind in range(stack.shape[2]):
+			shiftx, shifty = get_shift_hybrid(stack[:,:,anchorDP],stack[:,:,ind],corrPower)
+
+			#correct for the wraparound of the shifts from get_shift
+			if shiftx > int(wx/2): shiftx = shiftx - wx
+			if shifty > int(wy/2): shifty = shifty - wy
+
+			DPx,DPy = np.unravel_index(ind,xcent.shape)
+
+			nudgex[DPx,DPy] -= np.rint(shiftx*damping)
+			nudgey[DPx,DPy] -= np.rint(shifty*damping)
+
+			shifterr[ind] = shiftx**2 + shifty**2
+
+		newerr = np.sqrt(np.mean(shifterr.astype(float)))
+		err[iter] = newerr
+
+		assert np.max(np.abs((nudgex,nudgey))) < maxshift, "Maximum shift exceeded."
+
+	bestx = xcent + nudgex
+	besty = ycent + nudgey
+
+	stack0 = slice_subframes(testDP,xcent,ycent,wx,wy)
+
+	fig, ax = subplots(xcent.shape[0],xcent.shape[1],figsize=(10,10)):
+
+	for Rx in np.arange(xcent.shape[0]):
+		for Ry in np.arange(xcent.shape[1]):
+			ind = np.ravel_multi_index((Rx,Ry),(xcent.shape[0],xcent.shape[1]))
+			ax[Rx,Ry].imshow(stack[:,:,ind]-stack0[:,:,ind], cmap='RdBu')
+			ax[Rx,Ry].axis('off')
+
+	plt.show()
+
+	fig2, ax2 = subplots(xcent.shape[0],xcent.shape[1],figsize=(10,10)):
+
+	for Rx in np.arange(xcent.shape[0]):
+		for Ry in np.arange(xcent.shape[1]):
+			ind = np.ravel_multi_index((Rx,Ry),(xcent.shape[0],xcent.shape[1]))
+			ax2[Rx,Ry].imshow(stack[:,:,ind])
+			ax2[Rx,Ry].axis('off')
+
+	plt.show()
+
+	return bestx, besty, err
+
+
+def slice_mrc_stack(mrc, scratch, scanshape, optx, opty, wx=500, wy=500):
+	"""
+	Slice the *.mrc movie into all of its subframes
+
+	mrc 		(MrcMemmap) memory map into the mrc file (opened by py4DSTEM.file.readwrite.read(...,load='relativity'))
+	scratch 	(str) path to a scratch file where a numpy memmap containing the re-sliced stack will be buffered
+				      NOTE! this will overwrite whatever file is at this path! be careful!
+  	scanshape	(numpy array) 2-element array containing the scan shape (Rx, Ry)
+	optx, opty 	(numpy meshgrids) the optimized centers of the subframes from subframeAlign(...)
+	wx,wy 		(ints) subframe sizes x and y
+
+	Returns:
+	dc 			(DataCube) a py4DSTEM DataCube containing the sliced up stack, in the correct order
+	"""
+
+	nframe = scansize.prod()//optx.size
+
+	dshape = (int(nframe),int(optx.size),wx,wy)
+
+	vstack = np.memmap(scratch, mode='w+', dtype='<i2', shape=dshape)
+
+	f = FloatProgress(min=0,max=nframe-1)
+	display(f)
+
+	t0 = time()
+
+	for i in np.arange(startframe,startframe+nframe):
+		f.value = i
+		frame = mrc.data[int(i),:,:]
+		stack = slice_subframes(frame,optx,opty,wx,wy)
+		vstack[int(i-startframe),:,:,:] = np.transpose(stack,(2,0,1))
+
+	t = time() - t0
+
+	print("Sliced {} diffraction patterns in {}h {}m {}s".format(scansize.prod(), int(t/3600),int(t/60), int(t%60)))
+	mrc.close()
+
+	dc = DataCube(vstack)
+	dc.set_scan_shape(scanshape[0],scanshape[1])
+
+

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -117,7 +117,7 @@ def slice_mrc_stack(mrc, scratch, scanshape, optx, opty, wx=500, wy=500):
 	dc 			(DataCube) a py4DSTEM DataCube containing the sliced up stack, in the correct order
 	"""
 
-	nframe = scansize.prod()//optx.size
+	nframe = scanshape.prod()//optx.size
 
 	dshape = (int(nframe),int(optx.size),wx,wy)
 
@@ -136,7 +136,7 @@ def slice_mrc_stack(mrc, scratch, scanshape, optx, opty, wx=500, wy=500):
 
 	t = time() - t0
 
-	print("Sliced {} diffraction patterns in {}h {}m {}s".format(scansize.prod(), int(t/3600),int(t/60), int(t%60)))
+	print("Sliced {} diffraction patterns in {}h {}m {}s".format(scanshape.prod(), int(t/3600),int(t/60), int(t%60)))
 	mrc.close()
 
 	dc = DataCube(vstack)

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -5,12 +5,6 @@ from ipywidgets import FloatProgress
 from time import time
 from ...file.datastructure import DataCube
 
-def read_mrc_file(filename):
-	import mrcfile
-	# read in an *.mrc file as an MRC memmap
-	return mrcfile.mmap(filename,mode='r')
-
-
 def slice_subframes(frame, x_cent, y_cent, wx=500, wy=500):
 	"""
 	Slice a movie frame into subframes, given the center points x_cent and y_cent (which are numpy meshgrids)

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -129,7 +129,7 @@ def slice_mrc_stack(mrc, scratch, scanshape, optx, opty, startframe=0, wx=500, w
 	t0 = time()
 
 	for i in np.arange(startframe,startframe+nframe):
-		f.value = i
+		f.value = i-startframe
 		frame = mrc.data[int(i),:,:]
 		stack = slice_subframes(frame,optx,opty,wx,wy)
 		vstack[int(i-startframe),:,:,:] = np.transpose(stack,(2,0,1))

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -25,7 +25,7 @@ def slice_subframes(frame, x_cent, y_cent, wx=500, wy=500):
 	return stack
 
 
-def subframeAlign(testDP, xcent, ycent, wx=500, wy=500, niter=10, maxshift=80, anchorDP=0, corrPower=0.5, damping=1 ):
+def subframe_align(testDP, xcent, ycent, wx=500, wy=500, niter=10, maxshift=80, anchorDP=0, corrPower=0.5, damping=1 ):
 	"""
 	Detrmine the alignment of the subframes in a Relativity frame by gradient descent. Arguments are:
 

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -1,3 +1,16 @@
+# -*- coding: utf-8 -*-
+
+# Reads an IDES Relativity file, determines the locations of the subframes, and splits them into a stack.
+#
+# The IDES Relativity splits the camera area into a matrix of subframes, which gives a higher framerate than
+# the native capability of the camera (1280 fps in 4x4 mode on the NCEM ThemIS). The frames are slightly
+# overlapping and highly distorted. This file provides functions for reading the *.mrc movies containing
+# the frames, locating the subframes and cropping them, measuring the distortion in each subframe, and
+# finally extracting a corrected DataCube from the movie.
+# 
+# Created on 7 May 2019
+# @author: sezeltmann
+
 import numpy as np
 from ..utils import get_shift_hybrid
 import matplotlib.pyplot as plt

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -1,5 +1,4 @@
 import numpy as np
-import mrcfile
 from ..utils import get_shift_hybrid
 import matplotlib.pyplot as plt
 from ipywidgets import FloatProgress
@@ -7,6 +6,7 @@ from time import time
 from ...file.datastructure import DataCube
 
 def read_mrc_file(filename):
+	import mrcfile
 	# read in an *.mrc file as an MRC memmap
 	return mrcfile.mmap(filename,mode='r')
 

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -87,7 +87,7 @@ def subframeAlign(testDP, xcent, ycent, wx=500, wy=500, niter=10, maxshift=80, a
 
 	plt.show()
 
-	fig2, ax2 = subplots(xcent.shape[0],xcent.shape[1],figsize=(10,10)):
+	fig2, ax2 = subplots(xcent.shape[0],xcent.shape[1],figsize=(10,10))
 
 	for Rx in np.arange(xcent.shape[0]):
 		for Ry in np.arange(xcent.shape[1]):

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -110,9 +110,11 @@ def slice_mrc_stack(mrc, scratch, scanshape, optx, opty, wx=500, wy=500):
 	"""
 	Slice the *.mrc movie into all of its subframes
 
-	mrc 		(MrcMemmap) memory map into the mrc file (opened by py4DSTEM.file.readwrite.read(...,load='relativity'))
+	mrc 		(MrcMemmap) memory map into the mrc file (such as opened by py4DSTEM.file.readwrite.read(...,load='relativity'))
 	scratch 	(str) path to a scratch file where a numpy memmap containing the re-sliced stack will be buffered
-				      NOTE! this will overwrite whatever file is at this path! be careful!
+		      	NOTE! this will overwrite whatever file is at this path! be careful!
+		      	ALSO NOTE! this file is where the data in the DataCube will actually live!
+		      	Either save the DataCube as a py4DSTEM *.h5 or use separate scratches for different data!
   	scanshape	(numpy array) 2-element array containing the scan shape (Rx, Ry)
 	optx, opty 	(numpy meshgrids) the optimized centers of the subframes from subframeAlign(...)
 	wx,wy 		(ints) subframe sizes x and y
@@ -145,5 +147,7 @@ def slice_mrc_stack(mrc, scratch, scanshape, optx, opty, wx=500, wy=500):
 
 	dc = DataCube(vstack)
 	dc.set_scan_shape(scanshape[0],scanshape[1])
+
+	return dc
 
 

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -100,7 +100,7 @@ def subframeAlign(testDP, xcent, ycent, wx=500, wy=500, niter=10, maxshift=80, a
 	return bestx, besty, err
 
 
-def slice_mrc_stack(mrc, scratch, scanshape, optx, opty, wx=500, wy=500):
+def slice_mrc_stack(mrc, scratch, scanshape, optx, opty, startframe=0, wx=500, wy=500):
 	"""
 	Slice the *.mrc movie into all of its subframes
 

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -77,7 +77,7 @@ def subframeAlign(testDP, xcent, ycent, wx=500, wy=500, niter=10, maxshift=80, a
 
 	stack0 = slice_subframes(testDP,xcent,ycent,wx,wy)
 
-	fig, ax = subplots(xcent.shape[0],xcent.shape[1],figsize=(10,10)):
+	fig, ax = subplots(xcent.shape[0],xcent.shape[1],figsize=(10,10))
 
 	for Rx in np.arange(xcent.shape[0]):
 		for Ry in np.arange(xcent.shape[1]):

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -77,7 +77,7 @@ def subframeAlign(testDP, xcent, ycent, wx=500, wy=500, niter=10, maxshift=80, a
 
 	stack0 = slice_subframes(testDP,xcent,ycent,wx,wy)
 
-	fig, ax = subplots(xcent.shape[0],xcent.shape[1],figsize=(10,10))
+	fig, ax = plt.subplots(xcent.shape[0],xcent.shape[1],figsize=(10,10))
 
 	for Rx in np.arange(xcent.shape[0]):
 		for Ry in np.arange(xcent.shape[1]):
@@ -87,7 +87,7 @@ def subframeAlign(testDP, xcent, ycent, wx=500, wy=500, niter=10, maxshift=80, a
 
 	plt.show()
 
-	fig2, ax2 = subplots(xcent.shape[0],xcent.shape[1],figsize=(10,10))
+	fig2, ax2 = plt.subplots(xcent.shape[0],xcent.shape[1],figsize=(10,10))
 
 	for Rx in np.arange(xcent.shape[0]):
 		for Ry in np.arange(xcent.shape[1]):

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -11,16 +11,16 @@ def slice_subframes(frame, x_cent, y_cent, wx=500, wy=500):
 	and the subframe width wx, wy
 	Returns a 3D stack of diffraction patterns.
 	"""
-	nDP = xcents.shape[0] * xcents.shape[1]
+	nDP = x_cent.shape[0] * x_cent.shape[1]
 	stack = np.zeros((wx,wy,nDP))
 
 	dx = np.round(wx/2).astype(int)
 	dy = np.round(wy/2).astype(int)
 
-	for Rx in range(xcents.shape[0]):
-		for Ry in range(xcents.shape[1]):
-			DPind = np.ravel_multi_index((Rx,Ry),(xcents.shape[0],xcents.shape[1]))
-			stack[:,:,DPind] = np.roll(DP,(-(xcents[Rx,Ry]-dx),-(ycents[Rx,Ry]-dy)),axis=(0,1))[:wx,:wy]
+	for Rx in range(x_cent.shape[0]):
+		for Ry in range(x_cent.shape[1]):
+			DPind = np.ravel_multi_index((Rx,Ry),(x_cent.shape[0],x_cent.shape[1]))
+			stack[:,:,DPind] = np.roll(DP,(-(x_cent[Rx,Ry]-dx),-(y_cent[Rx,Ry]-dy)),axis=(0,1))[:wx,:wy]
 
 	return stack
 

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -20,7 +20,7 @@ def slice_subframes(frame, x_cent, y_cent, wx=500, wy=500):
 	for Rx in range(x_cent.shape[0]):
 		for Ry in range(x_cent.shape[1]):
 			DPind = np.ravel_multi_index((Rx,Ry),(x_cent.shape[0],x_cent.shape[1]))
-			stack[:,:,DPind] = np.roll(DP,(-(x_cent[Rx,Ry]-dx),-(y_cent[Rx,Ry]-dy)),axis=(0,1))[:wx,:wy]
+			stack[:,:,DPind] = np.roll(frame,(-(x_cent[Rx,Ry]-dx),-(y_cent[Rx,Ry]-dy)),axis=(0,1))[:wx,:wy]
 
 	return stack
 

--- a/py4DSTEM/process/utils/utils.py
+++ b/py4DSTEM/process/utils/utils.py
@@ -40,6 +40,15 @@ def get_shift(ar1,ar2):
     xshift,yshift = np.unravel_index(np.argmax(cc),ar1.shape)
     return xshift,yshift
 
+def get_shift_hybrid(ar1,ar2,corrPower=1):
+    """
+    Determine the relative shift between a pair of same-size arrays, specifying the
+    power of correlation. 1=cross, 0=phase. Returns maximal pixel of the correlogram
+    """
+    cc = get_cross_correlation(ar1,ar2,corrPower)
+    xshift,yshift = np.unravel_index(np.argmax(cc),ar1.shape)
+    return xshift, yshift
+
 def get_shifted_ar(ar,xshift,yshift):
     """
 	Shifts array ar by the shift vector (xshift,yshift), using the Fourier shift theorem (i.e.


### PR DESCRIPTION
Adds new `load='relativity'` option to `py4DSTEM.file.readwrite.read(...)` which opens an `*.mrc` file as a memory map. Adds `relativity.py` to `process.preprocess` which contains functions for:
* aligning subframes of a stack (`subframe_align`)
* `slice_mrc_stack`: converting the (3D) `*.mrc` stack stack into a `DataCube`. This operation requires a "scratch" file where a numpy memory map is buffered. Presumably, one would just save a py4DSTEM file to retain the stack and all the metadata after this, and get rid of/overwrite the scratch file. 

This adds dependency on `mrcfile` (which has to be `pip install`ed because it's not in conda) and uses the `FloatProgress` doodad from `ipywidgets` for a progress bar (which in my experience is quite sturdy). 

Also, I'm attaching a notebook with a usage example (though not the dataset, since it's several GB)
[usage example](https://github.com/py4dstem/py4DSTEM/files/3168037/module.test.ipynb.zip)

