### PR TITLE
Added support for saving a K2 dataset to h5 file

### DIFF
--- a/py4DSTEM/file/io/write.py
+++ b/py4DSTEM/file/io/write.py
@@ -198,7 +198,11 @@ def save_datacube_group(group, datacube):
         group.attrs.create("metadata",-1)
 
     # TODO: consider defining data chunking here, keeping k-space slices together
-    data_datacube = group.create_dataset("datacube", data=datacube.data4D)
+    if isinstance(datacube.data4D,np.ndarray):
+        data_datacube = group.create_dataset("datacube", data=datacube.data4D)
+    else:
+        # handle K2DataArray datacubes
+        data_datacube = datacube.data4D._write_to_hdf5(group)
 
     # Dimensions
     assert len(data_datacube.shape)==4, "Shape of datacube is {}".format(len(data_datacube))


### PR DESCRIPTION
Calling `py4DSTEM.file.io.save(dc,fpath)` on a DataCube loaded with `py4DSTEM.file.io.read(fpath,load='gatan_bin')` is now supported, and saves the data to a py4DSTEM HDF5 file.

Changed the datatype for K2 data to `int16`, which makes more sense than `float32` for this data, as I had earlier. 