### PR TITLE
Gui arrowkey

### DIFF
--- a/py4DSTEM/gui/dialogs.py
+++ b/py4DSTEM/gui/dialogs.py
@@ -398,12 +398,37 @@ class VirtualDetectorsWidget(QtWidgets.QWidget):
         self.buttonGroup_DetectorMode.setId(self.radioButton_CoMX, 3)
         self.buttonGroup_DetectorMode.setId(self.radioButton_CoMY, 4)
 
+        # Arrowkey Control
+        arrowkey_widget = QtWidgets.QWidget()
+        arrowkey_widget_layout = QtWidgets.QVBoxLayout()
+
+        self.radioButton_ArrowkeyRS = QtWidgets.QRadioButton('Real Space')
+        self.radioButton_ArrowkeyDP = QtWidgets.QRadioButton('Diffraction')
+        self.radioButton_ArrowkeyOff = QtWidgets.QRadioButton('None')
+        self.radioButton_ArrowkeyOff.setChecked(True)
+
+        arrowkey_widget_layout.addWidget(self.radioButton_ArrowkeyRS)
+        arrowkey_widget_layout.addWidget(self.radioButton_ArrowkeyDP)
+        arrowkey_widget_layout.addWidget(self.radioButton_ArrowkeyOff)
+        arrowkey_widget.setLayout(arrowkey_widget_layout)
+
+        self.buttonGroup_ArrowkeyMode = QtWidgets.QButtonGroup()
+        self.buttonGroup_ArrowkeyMode.addButton(self.radioButton_ArrowkeyRS)
+        self.buttonGroup_ArrowkeyMode.addButton(self.radioButton_ArrowkeyDP)
+        self.buttonGroup_ArrowkeyMode.addButton(self.radioButton_ArrowkeyOff)
+
+        self.buttonGroup_ArrowkeyMode.setId(self.radioButton_ArrowkeyRS,0)
+        self.buttonGroup_ArrowkeyMode.setId(self.radioButton_ArrowkeyDP,1)
+        self.buttonGroup_ArrowkeyMode.setId(self.radioButton_ArrowkeyOff,2)
+
         # Layout
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(SectionLabel('Detector Shape'))
         layout.addWidget(detector_shape_widget)
         layout.addWidget(SectionLabel('Detector Mode'))
         layout.addWidget(detector_mode_widget)
+        layout.addWidget(SectionLabel('Arrowkey Control'))
+        layout.addWidget(arrowkey_widget)
         layout.setSpacing(0)
         layout.setContentsMargins(0,0,0,0)
         self.setLayout(layout)

--- a/py4DSTEM/gui/viewer.py
+++ b/py4DSTEM/gui/viewer.py
@@ -757,7 +757,8 @@ class DataViewer(QtWidgets.QMainWindow):
                 y0 = (y0-1)%(self.datacube.data.shape[1])
             elif e.key() == QtCore.Qt.Key_Down:
                 y0 = (y0+1)%(self.datacube.data.shape[1])
-
+            else:
+                self.settings.arrowkey_mode.update_value(2) # relase keyboard control if you press anything else
             roi_state['pos'] = (x0-0.5,y0-0.5)
             self.real_space_point_selector.setState(roi_state)
         elif mode == 1: # we are in qspace mode
@@ -772,7 +773,8 @@ class DataViewer(QtWidgets.QMainWindow):
                 y0 = (y0-1)%(self.datacube.data.shape[3])
             elif e.key() == QtCore.Qt.Key_Down:
                 y0 = (y0+1)%(self.datacube.data.shape[3])
-
+            else:
+                self.settings.arrowkey_mode.update_value(2) # relase keyboard control if you press anything else
             roi_state['pos'] = (x0-0.5,y0-0.5)
             self.virtual_detector_roi.setState(roi_state)
 

--- a/py4DSTEM/gui/viewer.py
+++ b/py4DSTEM/gui/viewer.py
@@ -155,6 +155,10 @@ class DataViewer(QtWidgets.QMainWindow):
         self.settings.virtual_detector_shape.updated_value.connect(self.update_virtual_detector_shape)
         self.settings.virtual_detector_mode.updated_value.connect(self.update_virtual_detector_mode)
 
+        self.settings.New('arrowkey_mode',dtype=int,initial=2)
+        self.settings.arrowkey_mode.connect_bidir_to_widget(self.control_widget.virtualDetectors.widget.buttonGroup_ArrowkeyMode)
+        self.settings.arrowkey_mode.updated_value.connect(self.update_arrowkey_mode)
+
         return self.control_widget
 
     def setup_diffraction_space_widget(self):
@@ -737,7 +741,47 @@ class DataViewer(QtWidgets.QMainWindow):
 
         return
 
+    ######### Handle keypresses to move realspace cursor ##########
+    def keyPressEvent(self,e):
+        mode = self.settings.arrowkey_mode.val
 
+        if mode == 0: # we are in realspace mode
+            roi_state = self.real_space_point_selector.saveState()
+            x0,y0 = roi_state['pos']
+            x0,y0 = np.ceil(x0), np.ceil(y0)
+            if e.key() == QtCore.Qt.Key_Left:
+                x0 = (x0-1)%(self.datacube.data.shape[0])
+            elif e.key() == QtCore.Qt.Key_Right:
+                x0 = (x0+1)%(self.datacube.data.shape[0])
+            elif e.key() == QtCore.Qt.Key_Up:
+                y0 = (y0-1)%(self.datacube.data.shape[1])
+            elif e.key() == QtCore.Qt.Key_Down:
+                y0 = (y0+1)%(self.datacube.data.shape[1])
+
+            roi_state['pos'] = (x0-0.5,y0-0.5)
+            self.real_space_point_selector.setState(roi_state)
+        elif mode == 1: # we are in qspace mode
+            roi_state = self.virtual_detector_roi.saveState()
+            x0,y0 = roi_state['pos']
+            x0,y0 = np.ceil(x0), np.ceil(y0)
+            if e.key() == QtCore.Qt.Key_Left:
+                x0 = (x0-1)%(self.datacube.data.shape[2])
+            elif e.key() == QtCore.Qt.Key_Right:
+                x0 = (x0+1)%(self.datacube.data.shape[2])
+            elif e.key() == QtCore.Qt.Key_Up:
+                y0 = (y0-1)%(self.datacube.data.shape[3])
+            elif e.key() == QtCore.Qt.Key_Down:
+                y0 = (y0+1)%(self.datacube.data.shape[3])
+
+            roi_state['pos'] = (x0-0.5,y0-0.5)
+            self.virtual_detector_roi.setState(roi_state)
+
+    def update_arrowkey_mode(self):
+        mode = self.settings.arrowkey_mode.val
+        if mode == 2:
+            self.releaseKeyboard()
+        else:
+            self.grabKeyboard()
 
     def exec_(self):
         return self.qtapp.exec_()


### PR DESCRIPTION
I showed Karen the GUI and she requested this feature... So here it is! (Also she thinks the GUI is awesome!)

Qt handles keyboard events in... interesting ways? So I ended up making a radio button for where you want control to go. Since once you attach keyboard events to the widget it really holds on to it, I have set it up so if you press anything other than an arrow key it leaves arrowkey mode. Otherwise even putting the cursor in other places wouldn't wrest control and people might get confused/angry...