### PR TITLE
GatanK2: Add some support for numpy functions 

### DIFF
--- a/py4DSTEM/file/io/gatanK2.py
+++ b/py4DSTEM/file/io/gatanK2.py
@@ -404,6 +404,7 @@ class K2DataArray(Sequence):
         for sy in range(self.shape[1]):
             for sx in range(self.shape[0]):
                 dset[sx,sy,:,:] = self[sx,sy,:,:]
+                print_progress_bar(sy*self.shape[0] + sx + 1,self.shape[0]*self.shape[1])
 
         return dset
 

--- a/py4DSTEM/file/io/gatanK2.py
+++ b/py4DSTEM/file/io/gatanK2.py
@@ -164,8 +164,8 @@ class K2DataArray(Sequence):
                     print_progress_bar(Ry*self.shape[0] + Rx + 1,self.shape[0]*self.shape[1])
             return avgImg
 
-    def sum(axis=None, dtype=None, out=None, keepdims=False):
-        assert axis in [(0,1), (2,3)], 'Only average DP and average image supported.'
+    def sum(self, axis=None, dtype=None, out=None, keepdims=False):
+        assert axis in [(0,1), (2,3)], 'Only sum DP and sum image supported.'
 
         # handle average DP
         if axis == (0,1):
@@ -182,10 +182,32 @@ class K2DataArray(Sequence):
             sumImg = np.zeros((self.shape[0],self.shape[1]))
             for Ry in range(self.shape[1]):
                 for Rx in range(self.shape[0]):
-                    sumImg[Rx,Ry] = np.mean(self[Rx,Ry,:,:])
+                    sumImg[Rx,Ry] = np.sum(self[Rx,Ry,:,:])
                     print_progress_bar(Ry*self.shape[0] + Rx + 1,self.shape[0]*self.shape[1])
             return sumImg
-    
+
+
+    def max(self, axis=None, out=None):
+        assert axis in [(0,1), (2,3)], 'Only max DP and max image supported.'
+
+        # handle average DP
+        if axis == (0,1):
+            maxDP = np.zeros((self.shape[2],self.shape[3]))
+            for Ry in range(self.shape[1]):
+                for Rx in range(self.shape[0]):
+                    maxDP = np.maximum(maxDP,self[Rx,Ry,:,:])
+                    print_progress_bar(Ry*self.shape[0] + Rx + 1,self.shape[0]*self.shape[1])
+
+            return maxDP
+
+        #handle average image
+        if axis == (2,3):
+            maxImg = np.zeros((self.shape[0],self.shape[1]))
+            for Ry in range(self.shape[1]):
+                for Rx in range(self.shape[0]):
+                    maxImg[Rx,Ry] = np.max(self[Rx,Ry,:,:])
+                    print_progress_bar(Ry*self.shape[0] + Rx + 1,self.shape[0]*self.shape[1])
+            return maxImg
     
     #====== READING FROM BINARY AND NOISE REDUCTION ======#
     def _attach_to_files(self):

--- a/py4DSTEM/file/io/gatanK2.py
+++ b/py4DSTEM/file/io/gatanK2.py
@@ -91,6 +91,8 @@ class K2DataArray(Sequence):
         print('Shutter flags are:',self._shutter_offsets)
 
         self._gtg_meta = gtg.allTags
+
+        self._verbose = False
                 
         super().__init__()
 
@@ -161,6 +163,28 @@ class K2DataArray(Sequence):
                     avgImg[Rx,Ry] = np.mean(self[Rx,Ry,:,:])
                     print_progress_bar(Ry*self.shape[0] + Rx + 1,self.shape[0]*self.shape[1])
             return avgImg
+
+    def sum(axis=None, dtype=None, out=None, keepdims=False):
+        assert axis in [(0,1), (2,3)], 'Only average DP and average image supported.'
+
+        # handle average DP
+        if axis == (0,1):
+            sumDP = np.zeros((self.shape[2],self.shape[3]))
+            for Ry in range(self.shape[1]):
+                for Rx in range(self.shape[0]):
+                    sumDP += self[Rx,Ry,:,:]
+                    print_progress_bar(Ry*self.shape[0] + Rx + 1,self.shape[0]*self.shape[1])
+
+            return sumDP
+
+        #handle average image
+        if axis == (2,3):
+            sumImg = np.zeros((self.shape[0],self.shape[1]))
+            for Ry in range(self.shape[1]):
+                for Rx in range(self.shape[0]):
+                    sumImg[Rx,Ry] = np.mean(self[Rx,Ry,:,:])
+                    print_progress_bar(Ry*self.shape[0] + Rx + 1,self.shape[0]*self.shape[1])
+            return sumImg
     
     
     #====== READING FROM BINARY AND NOISE REDUCTION ======#

--- a/py4DSTEM/file/io/gatanK2.py
+++ b/py4DSTEM/file/io/gatanK2.py
@@ -5,6 +5,7 @@
 from collections.abc import Sequence
 import numpy as np
 import numba as nb
+from ...process.utils import print_progress_bar
 
 class K2DataArray(Sequence):
     """
@@ -136,6 +137,30 @@ class K2DataArray(Sequence):
         
     def __len__(self):
         return np.prod(self.shape)
+
+    #====== DUCK-TYPED NUMPY FUNCTIONS ======#
+
+    def mean(self, axis=None, dtype=None, out=None, keepdims=False):
+        assert axis in [(0,1), (2,3)], 'Only average DP and average image supported.'
+
+        # handle average DP
+        if axis == (0,1):
+            avgDP = np.zeros((self.shape[2],self.shape[3]))
+            for Ry in range(self.shape[1]):
+                for Rx in range(self.shape[0]):
+                    avgDP += self[Rx,Ry,:,:]
+                    print_progress_bar(Ry*self.shape[0] + Rx + 1,self.shape[0]*self.shape[1])
+
+            return avgDP / (self.shape[0]*self.shape[1])
+
+        #handle average image
+        if axis == (2,3):
+            avgImg = np.zeros((self.shape[0],self.shape[1]))
+            for Ry in range(self.shape[1]):
+                for Rx in range(self.shape[0]):
+                    avgImg[Rx,Ry] = np.mean(self[Rx,Ry,:,:])
+                    print_progress_bar(Ry*self.shape[0] + Rx + 1,self.shape[0]*self.shape[1])
+            return avgImg
     
     
     #====== READING FROM BINARY AND NOISE REDUCTION ======#

--- a/py4DSTEM/file/io/gatanK2.py
+++ b/py4DSTEM/file/io/gatanK2.py
@@ -91,8 +91,6 @@ class K2DataArray(Sequence):
         print('Shutter flags are:',self._shutter_offsets)
 
         self._gtg_meta = gtg.allTags
-
-        self._verbose = False
                 
         super().__init__()
 


### PR DESCRIPTION
This adds limited duck-typed support for numpy functions to the K2DataArray memory map.

The following are now valid for data read with the `load='gatan_bin'` option:

```python
avgDP = np.mean(dc.data,axis=(0,1))
avgImg = np.mean(dc.data,axis=(2,3))

sumDP = np.sum(dc.data,axis=(0,1))
sumImg = np.sum(dc.data,axis=(2,3))

maxDP = np.max(dc.data,axis=(0,1))
maxImg = np.max(dc.data,axis=(2,3))
```

This should be safe so I'm PR'ing into the dev branch rather than the experimental IO branch.