### PR TITLE
Better exception handling with file reading

### DIFF
--- a/py4DSTEM/file/io/read.py
+++ b/py4DSTEM/file/io/read.py
@@ -74,8 +74,12 @@ def read(filename, load=None):
     if not is_py4DSTEM_file(filename):
         print("{} is not a py4DSTEM file.".format(filename))
         if load is None:
-            print("Reading with hyperspy...")
-            output = read_with_hyperspy(filename)
+            print("Couldn't identify input, attempting to read with hyperspy...")
+            try:
+                output = read_with_hyperspy(filename)
+            except:
+                print("Hyperspy read failed")
+                return "Hyperspy read failed"
         elif load == 'dmmmap':
             print("Memory mapping a dm file...")
             output = read_dm_mmap(filename)

--- a/py4DSTEM/gui/viewer.py
+++ b/py4DSTEM/gui/viewer.py
@@ -205,7 +205,13 @@ class DataViewer(QtWidgets.QMainWindow):
         self.kernel_client = self.kernel_manager.client()
         self.kernel_client.start_channels()
 
-        self.console_widget = RichJupyterWidget()
+        #Avoid setting up multiple consoles
+        alreadysetup = False
+        if hasattr(self,'console_widget'):
+            if (isinstance(self.console_widget,RichJupyterWidget)):
+                alreadysetup = True
+
+        if not alreadysetup: self.console_widget = RichJupyterWidget()
         self.console_widget.setWindowTitle("py4DSTEM IPython Console")
         self.console_widget.kernel_manager = self.kernel_manager
         self.console_widget.kernel_client = self.kernel_client
@@ -258,6 +264,12 @@ class DataViewer(QtWidgets.QMainWindow):
         msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
         msg.exec_()
 
+    def Unidentified_file(self,fname):
+        msg = QtWidgets.QMessageBox()
+        msg.setText("Couldn't open {0} as it doesn't conform to currently implemented py4DSTEM standards".format(fname))
+        msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
+        msg.exec_()
+
     def load_file(self):
         """
         Loads a file by creating and storing a DataCube object.
@@ -275,6 +287,11 @@ class DataViewer(QtWidgets.QMainWindow):
         self.datacube = None
         gc.collect()
         self.datacube = read(fname)
+        if type(self.datacube) == str : 
+            self.Unidentified_file(fname)
+            #Reset view
+            self.__init__(sys.argv)
+            return
 
         # Update scan shape information
         self.settings.R_Nx.update_value(self.datacube.R_Nx)


### PR DESCRIPTION
Creates an error message and resets the viewer if a file cannot be opened rather than crashing.