### PR TITLE
fix index error for h5 datasets in GUI, normalize indices for cursor …

### DIFF
--- a/py4DSTEM/file/datastructure/datacube.py
+++ b/py4DSTEM/file/datastructure/datacube.py
@@ -28,6 +28,7 @@ class DataCube(DataObject):
             self.R_Nx, self.R_Ny, self.Q_Nx, self.Q_Ny = data.shape
             self.R_N = self.R_Nx*self.R_Ny
 
+        self.update_slice_parsers()
         # Set shape
         # TODO: look for shape in metadata
         # TODO: AND/OR look for R_Nx... in kwargs
@@ -44,18 +45,21 @@ class DataCube(DataObject):
         Reshape the data given the real space scan shape.
         """
         self = preprocess.set_scan_shape(self,R_Nx,R_Ny)
+        self.update_slice_parsers()
 
     def swap_RQ(self):
         """
         Swap real and reciprocal space coordinates.
         """
         self = preprocess.swap_RQ(self)
+        self.update_slice_parsers()
 
     def swap_Rxy(self):
         """
         Swap real space x and y coordinates.
         """
         self = preprocess.swap_Rxy(self)
+        self.update_slice_parsers()
 
     def swap_Qxy(self):
         """
@@ -82,15 +86,22 @@ class DataCube(DataObject):
 
     ################ Slice data #################
 
+    def update_slice_parsers(self):
+        # define index-sanitizing functions:
+        self.normX = lambda x: np.maximum(0,np.minimum(self.R_Nx-1,x))
+        self.normY = lambda x: np.maximum(0,np.minimum(self.R_Ny-1,x))
+
     def get_diffraction_space_view(self,Rx=0,Ry=0):
         """
         Returns the image in diffraction space, and a Bool indicating success or failure.
         """
-        self.Rx,self.Ry = Rx,Ry
+        self.Rx,self.Ry = self.normX(Rx),self.normY(Ry)
         try:
-            return self.data[Rx,Ry,:,:], 1
+            return self.data[self.Rx,self.Ry,:,:], 1
         except IndexError:
             return 0, 0
+        except ValueError:
+            return 0,0
 
     # Virtual images -- integrating
 

--- a/py4DSTEM/file/io/write.py
+++ b/py4DSTEM/file/io/write.py
@@ -214,7 +214,8 @@ def save_datacube_group(group, datacube):
 
     # TODO: consider defining data chunking here, keeping k-space slices together
     if isinstance(datacube.data,np.ndarray) or (isinstance(datacube.data,h5py.Dataset)):
-        data_datacube = group.create_dataset("data", data=datacube.data)
+        data_datacube = group.create_dataset("data", data=datacube.data,
+            chunks=(2,2,datacube.Q_Nx,datacube.Q_Ny),compression='gzip')
     else:
         # handle K2DataArray datacubes
         data_datacube = datacube.data._write_to_hdf5(group)

--- a/py4DSTEM/file/io/write.py
+++ b/py4DSTEM/file/io/write.py
@@ -213,7 +213,7 @@ def save_datacube_group(group, datacube):
         group.attrs.create("metadata",-1)
 
     # TODO: consider defining data chunking here, keeping k-space slices together
-    if isinstance(datacube.data,np.ndarray):
+    if isinstance(datacube.data,np.ndarray) or (isinstance(datacube.data,h5py.Dataset)):
         data_datacube = group.create_dataset("data", data=datacube.data)
     else:
         # handle K2DataArray datacubes

--- a/py4DSTEM/file/io/write.py
+++ b/py4DSTEM/file/io/write.py
@@ -215,7 +215,7 @@ def save_datacube_group(group, datacube):
     # TODO: consider defining data chunking here, keeping k-space slices together
     if isinstance(datacube.data,np.ndarray) or (isinstance(datacube.data,h5py.Dataset)):
         data_datacube = group.create_dataset("data", data=datacube.data,
-            chunks=(2,2,datacube.Q_Nx,datacube.Q_Ny),compression='gzip')
+            chunks=(1,1,datacube.Q_Nx,datacube.Q_Ny),compression='gzip')
     else:
         # handle K2DataArray datacubes
         data_datacube = datacube.data._write_to_hdf5(group)

--- a/py4DSTEM/process/preprocess/preprocess.py
+++ b/py4DSTEM/process/preprocess/preprocess.py
@@ -27,6 +27,7 @@ def set_scan_shape(datacube,R_Nx,R_Ny):
         return datacube
     except AttributeError:
         print(f"Can't reshape {datacube.data.__class__.__name__} datacube.")
+        return datacube
 
 @log
 def swap_RQ(datacube):


### PR DESCRIPTION
fixes for saving h5 Datasets to new h5 files, h5 memmaps in GUI

adds compression for datacubes. this makes them ~30x smaller (for one test dataset) but makes them load virtual images in the GUI very slowly. I'll make a way around this later