### PR TITLE
fix for scatteringFactors missing

### DIFF
--- a/py4DSTEM/process/utils/single_atom_scatter.py
+++ b/py4DSTEM/process/utils/single_atom_scatter.py
@@ -16,8 +16,8 @@ class single_atom_scatter(object):
         self.composition = composition
         self.q_coords = q_coords
         self.units = units
-        path = os.path.dirname(__file__)
-        self.e_scattering_factors = np.loadtxt(path+'/scatteringFactors.txt',dtype=np.float)
+        path = os.path.join(os.path.dirname(__file__),'scatteringFactors.txt')
+        self.e_scattering_factors = np.loadtxt(path,dtype=np.float)
 
         return
 

--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,5 @@ setup(name='py4DSTEM',
         },
     entry_points= {
         'console_scripts': ['py4DSTEM=py4DSTEM.gui.runGUI:launch']
-    })
+    },
+    package_data = {'py4DSTEM':['process/utils/scatteringFactors.txt']})


### PR DESCRIPTION
Adds `scatteringFactors.txt` to the `package_data` in `setup.py` and use `os.path.join` to create the path, avoiding the front slash/back slash problem