### PR TITLE
Various patches

### DIFF
--- a/py4DSTEM/file/datastructure/metadata.py
+++ b/py4DSTEM/file/datastructure/metadata.py
@@ -61,6 +61,8 @@ class Metadata(object):
 
         # Original metadata - whatever is initially found at read time
         self.original_metadata = MetadataCollection('original_metadata')
+        self.original_metadata.shortlist = None
+        self.original_metadata.all = None
 
         # Search dictionaries
         self._search_dicts = MetadataCollection('search_dicts')

--- a/py4DSTEM/file/io/append.py
+++ b/py4DSTEM/file/io/append.py
@@ -14,7 +14,7 @@ from ..datastructure import DataObject, Metadata
 from ..log import log, Logger
 logger = Logger()
 
-@log
+#@log
 def append_from_dataobject_list(dataobject_list, filepath):
     """
     Appends new dataobjects to an existing py4DSTEM h5 file.
@@ -145,7 +145,7 @@ def append_from_dataobject_list(dataobject_list, filepath):
     print("Done.")
     f.close()
 
-@log
+#@log
 def append_dataobject(dataobject, filepath, **kwargs):
     """
     Appends dataobject to existing .h5 file at filepath.
@@ -155,7 +155,7 @@ def append_dataobject(dataobject, filepath, **kwargs):
     # append
     append_from_dataobject_list([dataobject], filepath, **kwargs)
 
-@log
+#@log
 def append_dataobjects_by_indices(index_list, filepath, **kwargs):
     """
     Appends the DataObjects found at the indices in index_list in DataObject.get_dataobjects to
@@ -166,7 +166,7 @@ def append_dataobjects_by_indices(index_list, filepath, **kwargs):
 
     append_from_dataobject_list(dataobject_list, filepath, **kwargs)
 
-@log
+#@log
 def append(data, filepath, **kwargs):
     """
     Appends data to an existing py4DSTEM .h5 file at filepath. What is saved depends on the

--- a/py4DSTEM/file/io/copy.py
+++ b/py4DSTEM/file/io/copy.py
@@ -18,7 +18,7 @@ from ..datastructure import DataObject, Metadata
 from ..log import log, Logger
 logger = Logger()
 
-@log
+#@log
 def copy_from_indices(original_filepath, new_filepath, indices):
     """
     Copies DataObjects specified by indices from the py4DSTEM .h5 file at original_filepath to a
@@ -54,7 +54,7 @@ def copy_from_indices(original_filepath, new_filepath, indices):
     ##### Finish and close #####
     browser.close()
 
-@log
+#@log
 def copy_datacubes(original_filepath, new_filepath):
     """
     Copies only the DataCubes from original filepath to new_filepath.
@@ -73,7 +73,7 @@ def copy_datacubes(original_filepath, new_filepath):
     ##### Finish and close #####
     browser.close()
 
-@log
+#@log
 def copy_diffractionslices(original_filepath, new_filepath):
     """
     Copies only the DiffractionSlices from original filepath to new_filepath.
@@ -92,7 +92,7 @@ def copy_diffractionslices(original_filepath, new_filepath):
     ##### Finish and close #####
     browser.close()
 
-@log
+#@log
 def copy_realslices(original_filepath, new_filepath):
     """
     Copies only the RealSlices from original filepath to new_filepath.
@@ -111,7 +111,7 @@ def copy_realslices(original_filepath, new_filepath):
     ##### Finish and close #####
     browser.close()
 
-@log
+#@log
 def copy_pointlists(original_filepath, new_filepath):
     """
     Copies only the PointLists from original filepath to new_filepath.
@@ -130,7 +130,7 @@ def copy_pointlists(original_filepath, new_filepath):
     ##### Finish and close #####
     browser.close()
 
-@log
+#@log
 def copy_pointlistarrays(original_filepath, new_filepath):
     """
     Copies only the pointlistarrays from original filepath to new_filepath.
@@ -149,7 +149,7 @@ def copy_pointlistarrays(original_filepath, new_filepath):
     ##### Finish and close #####
     browser.close()
 
-@log
+#@log
 def copy_all(original_filepath, new_filepath):
     """
     Copies all DataObjects from original filepath to new_filepath.
@@ -168,7 +168,7 @@ def copy_all(original_filepath, new_filepath):
     ##### Finish and close #####
     browser.close()
 
-@log
+#@log
 def copy_all_except_datacubes(original_filepath, new_filepath):
     """
     Copies all DataObjects from original filepath to new_filepath.
@@ -191,7 +191,7 @@ def copy_all_except_datacubes(original_filepath, new_filepath):
     ##### Finish and close #####
     browser.close()
 
-@log
+#@log
 def copy(original_filepath, new_filepath, save='all'):
     """
     Copies DataObjects specified by indices from the py4DSTEM .h5 file at original_filepath to a

--- a/py4DSTEM/file/io/read.py
+++ b/py4DSTEM/file/io/read.py
@@ -30,7 +30,7 @@ from ...process.utils import bin2D, tqdmnd
 
 ###################### BEGIN read FUNCTIONS ########################
 
-@log
+#@log
 def read(filename, load=None):
     """
     General read function.  Takes a filename as input, and outputs some py4DSTEM dataobjects.

--- a/py4DSTEM/file/io/remove.py
+++ b/py4DSTEM/file/io/remove.py
@@ -9,7 +9,7 @@ from .filebrowser import is_py4DSTEM_file, FileBrowser
 from ..log import log, Logger
 logger = Logger()
 
-@log
+#@log
 def remove_from_index_list(indices, filepath):
     """
     Remove existing dataobjects from a py4DSTEM h5 file.
@@ -59,7 +59,7 @@ def remove_from_index_list(indices, filepath):
     print("Done.")
     f.close()
 
-@log
+#@log
 def remove(dataobjects, filepath):
     """
     Remove existing dataobjects from a py4DSTEM h5 file.

--- a/py4DSTEM/file/io/write.py
+++ b/py4DSTEM/file/io/write.py
@@ -455,12 +455,13 @@ def save_metadata(metadata,group):
     transfer_metadata_dict(metadata.comments,group_comments_metadata)
 
     # Transfer original metadata trees
-    if type(metadata.original_metadata.shortlist)==DictionaryTreeBrowser:
-        transfer_metadata_tree_hs(metadata.original_metadata.shortlist,group_original_metadata_shortlist)
-        transfer_metadata_tree_hs(metadata.original_metadata.all,group_original_metadata_all)
-    else:
-        transfer_metadata_tree_py4DSTEM(metadata.original_metadata.shortlist,group_original_metadata_shortlist)
-        transfer_metadata_tree_py4DSTEM(metadata.original_metadata.all,group_original_metadata_all)
+    if metadata.original_metadata.shortlist is not None:
+        if type(metadata.original_metadata.shortlist)==DictionaryTreeBrowser:
+            transfer_metadata_tree_hs(metadata.original_metadata.shortlist,group_original_metadata_shortlist)
+            transfer_metadata_tree_hs(metadata.original_metadata.all,group_original_metadata_all)
+        else:
+            transfer_metadata_tree_py4DSTEM(metadata.original_metadata.shortlist,group_original_metadata_shortlist)
+            transfer_metadata_tree_py4DSTEM(metadata.original_metadata.all,group_original_metadata_all)
 
 def transfer_metadata_dict(dictionary,group):
     """

--- a/py4DSTEM/file/io/write.py
+++ b/py4DSTEM/file/io/write.py
@@ -474,7 +474,7 @@ def transfer_metadata_dict(dictionary,group):
     """
     for key,val in dictionary.items():
         if type(val)==str:
-            group.attrs.create(key,np.string_(val))
+            group.attrs.create(key,np.unicode_(val))
         else:
             group.attrs.create(key,val)
 
@@ -493,7 +493,7 @@ def transfer_metadata_tree_hs(tree,group):
             transfer_metadata_tree_hs(tree[key],subgroup)
         else:
             if type(tree[key])==str:
-                group.attrs.create(key,np.string_(tree[key]))
+                group.attrs.create(key,np.unicode_(tree[key]))
             else:
                 group.attrs.create(key,tree[key])
 
@@ -587,7 +587,7 @@ def write_log_item(group_log, index, logged_item):
     group_inputs = group_logitem.create_group('inputs')
     for key,value in logged_item.inputs.items():
         if type(value)==str:
-            group_inputs.attrs.create(key, np.string_(value))
+            group_inputs.attrs.create(key, np.unicode_(value))
         elif isinstance(value,DataObject):
             if value.name == '':
                 if isinstance(value,DataCube):
@@ -610,8 +610,8 @@ def write_log_item(group_log, index, logged_item):
                 group_inputs.attrs.create(key, value)
             except TypeError:
                 group_inputs.attrs.create(key, np.string_(str(value)))
-    group_logitem.attrs.create('version', logged_item.version)
-    write_time_to_log_item(group_logitem, logged_item.datetime)
+    group_logitem.attrs.create('version', np.string_(logged_item.version))
+    write_time_to_log_item(group_logitem, np.string_(logged_item.datetime))
 
 def write_time_to_log_item(group_logitem, datetime):
     date = str(datetime.tm_year)+str(datetime.tm_mon)+str(datetime.tm_mday)

--- a/py4DSTEM/file/io/write.py
+++ b/py4DSTEM/file/io/write.py
@@ -474,7 +474,7 @@ def transfer_metadata_dict(dictionary,group):
     """
     for key,val in dictionary.items():
         if type(val)==str:
-            group.attrs.create(key,np.unicode_(val))
+            group.attrs.create(key,str(val))
         else:
             group.attrs.create(key,val)
 
@@ -493,7 +493,7 @@ def transfer_metadata_tree_hs(tree,group):
             transfer_metadata_tree_hs(tree[key],subgroup)
         else:
             if type(tree[key])==str:
-                group.attrs.create(key,np.unicode_(tree[key]))
+                group.attrs.create(key,str(tree[key]))
             else:
                 group.attrs.create(key,tree[key])
 
@@ -587,7 +587,7 @@ def write_log_item(group_log, index, logged_item):
     group_inputs = group_logitem.create_group('inputs')
     for key,value in logged_item.inputs.items():
         if type(value)==str:
-            group_inputs.attrs.create(key, np.unicode_(value))
+            group_inputs.attrs.create(key, str(value))
         elif isinstance(value,DataObject):
             if value.name == '':
                 if isinstance(value,DataCube):

--- a/py4DSTEM/file/io/write.py
+++ b/py4DSTEM/file/io/write.py
@@ -15,7 +15,7 @@ from ...process.utils import tqdmnd
 from ..log import log, Logger
 logger = Logger()
 
-@log
+#@log
 def save_from_dataobject_list(dataobject_list, outputfile, topgroup=None, overwrite=False, **kwargs):
     """
     Saves an h5 file from a list of DataObjects and an output filepath.

--- a/py4DSTEM/process/preprocess/darkreference.py
+++ b/py4DSTEM/process/preprocess/darkreference.py
@@ -5,7 +5,7 @@ from ...file import log
 
 #### Subtrack darkreference from datacube frame at (Rx,Ry) ####
 
-@log
+#@log
 def get_bksbtr_DP(datacube, darkref, Rx, Ry):
     """
     Returns a background subtracted diffraction pattern.
@@ -24,7 +24,7 @@ def get_bksbtr_DP(datacube, darkref, Rx, Ry):
 
 #### Get dark reference ####
 
-@log
+#@log
 def get_darkreference(datacube, N_frames, width_x=0, width_y=0, side_x='end', side_y='end'):
     """
     Gets a dark reference image.
@@ -70,7 +70,7 @@ def get_darkreference(datacube, N_frames, width_x=0, width_y=0, side_x='end', si
                                         np.mean(darkref_y)*width_y)/(width_x+width_y)
                                         # Mean has been added twice; subtract one off
 
-@log
+# @log
 def get_background_streaks(datacube, N_frames, width, side='end', direction='x'):
     """
     Gets background streaking in either the x- or y-direction, by finding the average of a strip of
@@ -100,7 +100,7 @@ def get_background_streaks(datacube, N_frames, width, side='end', direction='x')
     else:
         return get_background_streaks_y(datacube=datacube, N_frames=N_frames, width=width, side=side)
 
-@log
+# @log 
 def get_background_streaks_x(datacube, width, N_frames, side='start'):
     """
     Gets background streaking, by finding the average of a strip of pixels along the y-edge of the
@@ -134,7 +134,7 @@ def get_background_streaks_x(datacube, width, N_frames, side='start'):
     darkref += bkgrnd_streaks[np.newaxis,:]
     return darkref
 
-@log
+# @log
 def get_background_streaks_y(datacube, N_frames, width, side='start'):
     """
     Gets background streaking, by finding the average of a strip of pixels along the x-edge of the

--- a/py4DSTEM/process/preprocess/preprocess.py
+++ b/py4DSTEM/process/preprocess/preprocess.py
@@ -13,7 +13,7 @@ from ...file.log import log
 
 ### Editing datacube shape ###
 
-@log
+# @log
 def set_scan_shape(datacube,R_Nx,R_Ny):
     """
     Reshape the data given the real space scan shape.
@@ -29,7 +29,7 @@ def set_scan_shape(datacube,R_Nx,R_Ny):
         print(f"Can't reshape {datacube.data.__class__.__name__} datacube.")
         return datacube
 
-@log
+# @log
 def swap_RQ(datacube):
     """
     Swaps real and reciprocal space coordinates, so that if
@@ -40,7 +40,7 @@ def swap_RQ(datacube):
     datacube.data = np.moveaxis(np.moveaxis(datacube.data,2,0),3,1)
     datacube.R_Nx,datacube.R_Ny,datacube.Q_Nx,datacube.Q_Ny = datacube.Q_Nx,datacube.Q_Ny,datacube.R_Nx,datacube.R_Ny
 
-@log
+# @log
 def swap_Rxy(datacube):
     """
     Swaps real space x and y coordinates, so that if
@@ -51,7 +51,7 @@ def swap_Rxy(datacube):
     datacube.data = np.moveaxis(datacube.data,1,0)
     datacube.R_Nx,datacube.R_Ny = datacube.R_Ny,datacube.R_Nx
 
-@log
+# @log
 def swap_Qxy(datacube):
     """
     Swaps reciprocal space x and y coordinates, so that if
@@ -65,20 +65,20 @@ def swap_Qxy(datacube):
 
 ### Cropping and binning ###
 
-@log
+# @log
 def crop_data_diffraction(datacube,crop_Qx_min,crop_Qx_max,crop_Qy_min,crop_Qy_max):
     datacube.data = datacube.data[:,:,crop_Qx_min:crop_Qx_max,crop_Qy_min:crop_Qy_max]
     datacube.Q_Nx, datacube.Q_Ny = crop_Qx_max-crop_Qx_min, crop_Qy_max-crop_Qy_min
     return datacube
 
-@log
+# @log
 def crop_data_real(datacube,crop_Rx_min,crop_Rx_max,crop_Ry_min,crop_Ry_max):
     datacube.data = datacube.data[crop_Rx_min:crop_Rx_max,crop_Ry_min:crop_Ry_max,:,:]
     datacube.R_Nx, datacube.R_Ny = crop_Rx_max-crop_Rx_min, crop_Ry_max-crop_Ry_min
     datacube.R_N = datacube.R_Nx*datacube.R_Ny
     return datacube
 
-@log
+# @log
 def bin_data_diffraction(datacube, bin_factor):
     """
     Performs diffraction space binning of data by bin_factor.
@@ -101,7 +101,7 @@ def bin_data_diffraction(datacube, bin_factor):
         datacube.R_Nx,datacube.R_Ny,datacube.Q_Nx,datacube.Q_Ny = datacube.data.shape
         return datacube
 
-@log
+# @log
 def bin_data_mmap(datacube, bin_factor):
     """
     Performs diffraction space binning of data by bin_factor.
@@ -120,7 +120,7 @@ def bin_data_mmap(datacube, bin_factor):
     datacube.R_Nx,datacube.R_Ny,datacube.Q_Nx,datacube.Q_Ny = datacube.data.shape
     return datacube
 
-@log
+# @log
 def bin_data_real(datacube, bin_factor):
     """
     Performs diffraction space binning of data by bin_factor.


### PR DESCRIPTION
This contains several small fixes to address recent issues:

Solves issue #108 by correctly converting strings when they are saved to attributes.

Solves issue #109 by adding tests for the existence of the extended MetaData (shortlist and all) objects before attempting to write them.

"Solves" issue #110 by disabling logging. 

Solves issue #111 by properly converting strings for h5 attributes. The numpy `string_` datatype is ASCII-only, so this instead uses the `str` method to get variable-length unicode strings as needed by h5py for fields that could conceivably contain non-ASCII text.