### PR TITLE
small GUI and K3 DM fixes

### DIFF
--- a/py4DSTEM/gui/viewer.py
+++ b/py4DSTEM/gui/viewer.py
@@ -84,6 +84,14 @@ class DataViewer(QtWidgets.QMainWindow):
         self.diffraction_space_widget.ui.normDivideRadio.setChecked(True)
         self.diffraction_space_widget.normRadioChanged()
 
+        if len(argv) > 1:
+            path = os.path.abspath(argv[1])
+            try:
+                self.settings.data_filename.val = path
+                self.load_file()
+            except Exception:
+                print(f"Tried to set file to {path} but something went wrong...")
+
 
     ###############################################
     ############ Widget setup methods #############
@@ -328,6 +336,8 @@ class DataViewer(QtWidgets.QMainWindow):
         # Set scan size maxima
         self.control_widget.spinBox_Nx.setMaximum(self.datacube.R_N)
         self.control_widget.spinBox_Ny.setMaximum(self.datacube.R_N)
+
+        self.main_window.setWindowTitle(fname)
 
         return
 

--- a/py4DSTEM/gui/viewer.py
+++ b/py4DSTEM/gui/viewer.py
@@ -305,7 +305,7 @@ class DataViewer(QtWidgets.QMainWindow):
             if is_py4DSTEM_file(fname):
                 self.datacube = datacube_selector(fname)
             else:
-                self.datacube,_ = read(fname)
+                self.datacube = read(fname)
             if type(self.datacube) == str :
                 self.Unidentified_file(fname)
                 #Reset view

--- a/py4DSTEM/io/nonnative/read_dm.py
+++ b/py4DSTEM/io/nonnative/read_dm.py
@@ -6,6 +6,7 @@ from ncempy.io import dm
 from ..datastructure import DataCube, Metadata
 from ...process.utils import bin2D
 
+
 def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
     """
     Read a digital micrograph 4D-STEM file.
@@ -28,39 +29,48 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
                     metadata is read and returned, in the former case a DataCube
                     is returned with the metadata attached at datacube.metadata
     """
-    assert(isinstance(fp,(str,Path))), "Error: filepath fp must be a string or pathlib.Path"
-    assert(mem in ['RAM','MEMMAP']), 'Error: argument mem must be either "RAM" or "MEMMAP"'
-    assert(isinstance(binfactor,int)), "Error: argument binfactor must be an integer"
-    assert(binfactor>=1), "Error: binfactor must be >= 1"
+    assert isinstance(
+        fp, (str, Path)
+    ), "Error: filepath fp must be a string or pathlib.Path"
+    assert mem in [
+        "RAM",
+        "MEMMAP",
+    ], 'Error: argument mem must be either "RAM" or "MEMMAP"'
+    assert isinstance(binfactor, int), "Error: argument binfactor must be an integer"
+    assert binfactor >= 1, "Error: binfactor must be >= 1"
 
     md = get_metadata_from_dmFile(fp)
     if metadata:
         return md
 
-    if (mem,binfactor)==("RAM",1):
-        with dm.fileDM(fp,on_memory=True) as dmFile:
+    if (mem, binfactor) == ("RAM", 1):
+        with dm.fileDM(fp, on_memory=True) as dmFile:
             dataSet = dmFile.getDataset(0)
-            dc = DataCube(data=dataSet['data'])
-    elif (mem,binfactor)==("MEMMAP",1):
+            dc = DataCube(data=dataSet["data"])
+    elif (mem, binfactor) == ("MEMMAP", 1):
         with dm.fileDM(fp, on_memory=False) as dmFile:
             memmap = dmFile.getMemmap(0)
             dc = DataCube(data=memmap)
-    elif (mem)==("RAM"):
+    elif (mem) == ("RAM"):
         with dm.fileDM(fp, on_memory=True) as dmFile:
             memmap = dmFile.getMemmap(0)
-        if 'dtype' in kwargs.keys():
-            dtype = kwargs['dtype']
+        if "dtype" in kwargs.keys():
+            dtype = kwargs["dtype"]
         else:
             dtype = memmap.dtype
-        R_Nx,R_Ny,Q_Nx,Q_Ny = memmap.shape
-        Q_Nx, Q_Ny = Q_Nx//binfactor, Q_Ny//binfactor
-        data = np.empty((R_Nx,R_Ny,Q_Nx,Q_Ny),dtype=dtype)
+        R_Nx, R_Ny, Q_Nx, Q_Ny = memmap.shape
+        Q_Nx, Q_Ny = Q_Nx // binfactor, Q_Ny // binfactor
+        data = np.empty((R_Nx, R_Ny, Q_Nx, Q_Ny), dtype=dtype)
         for Rx in range(R_Nx):
             for Ry in range(R_Ny):
-                data[Rx,Ry,:,:] = bin2D(memmap[Rx,Ry,:,:,],binfactor,dtype=dtype)
+                data[Rx, Ry, :, :] = bin2D(
+                    memmap[Rx, Ry, :, :,], binfactor, dtype=dtype
+                )
         dc = DataCube(data=data)
     else:
-        raise Exception("Memory mapping and on-load binning together is not supported.  Either set binfactor=1 or mem='RAM'.")
+        raise Exception(
+            "Memory mapping and on-load binning together is not supported.  Either set binfactor=1 or mem='RAM'."
+        )
         return
 
     dc.metadata = md
@@ -75,19 +85,16 @@ def get_metadata_from_dmFile(fp):
     with dm.fileDM(fp, on_memory=False) as dmFile:
         pixelSizes = dmFile.scale
         pixelUnits = dmFile.scaleUnit
-        assert(pixelSizes[0]==pixelSizes[1]), "Rx and Ry pixel sizes don't match"
-        assert(pixelSizes[2]==pixelSizes[3]), "Qx and Qy pixel sizes don't match"
-        assert(pixelUnits[0]==pixelUnits[1]), "Rx and Ry pixel units don't match"
-        assert(pixelUnits[2]==pixelUnits[3]), "Qx and Qy pixel units don't match"
+        assert pixelSizes[0] == pixelSizes[1], "Rx and Ry pixel sizes don't match"
+        assert pixelSizes[2] == pixelSizes[3], "Qx and Qy pixel sizes don't match"
+        assert pixelUnits[0] == pixelUnits[1], "Rx and Ry pixel units don't match"
+        assert pixelUnits[2] == pixelUnits[3], "Qx and Qy pixel units don't match"
         for i in range(len(pixelUnits)):
-            if pixelUnits[i]=='':
-                pixelUnits[i] = 'pixels'
+            if pixelUnits[i] == "":
+                pixelUnits[i] = "pixels"
         metadata.set_R_pixel_size__microscope(pixelSizes[0])
         metadata.set_R_pixel_size_units__microscope(pixelUnits[0])
         metadata.set_Q_pixel_size__microscope(pixelSizes[2])
         metadata.set_Q_pixel_size_units__microscope(pixelUnits[2])
 
     return metadata
-
-
-

--- a/py4DSTEM/io/nonnative/read_dm.py
+++ b/py4DSTEM/io/nonnative/read_dm.py
@@ -29,15 +29,10 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
                     metadata is read and returned, in the former case a DataCube
                     is returned with the metadata attached at datacube.metadata
     """
-    assert isinstance(
-        fp, (str, Path)
-    ), "Error: filepath fp must be a string or pathlib.Path"
-    assert mem in [
-        "RAM",
-        "MEMMAP",
-    ], 'Error: argument mem must be either "RAM" or "MEMMAP"'
-    assert isinstance(binfactor, int), "Error: argument binfactor must be an integer"
-    assert binfactor >= 1, "Error: binfactor must be >= 1"
+    assert(isinstance(fp,(str,Path))), "Error: filepath fp must be a string or pathlib.Path"
+    assert(mem in ['RAM','MEMMAP']), 'Error: argument mem must be either "RAM" or "MEMMAP"'
+    assert(isinstance(binfactor,int)), "Error: argument binfactor must be an integer"
+    assert(binfactor>=1), "Error: binfactor must be >= 1"
 
     md = get_metadata_from_dmFile(fp)
     if metadata:


### PR DESCRIPTION
This PR adds the ability to pass a filename as a command line argument when launching the GUI to immediately load that file, i.e. 
```
py4DSTEM /path/to/some/lovely/data/dm4
``` 
will open that lovely data in the GUI.

This also adds a fix for consolidated K3-produced `dm4` files. Such file contain the preview image, auto-generated VBF image, and a diffraction pattern, along with the 4D data in one `dm4` file. The K3 has been configured to not consolidate files by default anymore, but there are some such files still floating around in the wild. This fix is very old, and has been floating around as a patch with a few people, but I am finally submitting it for merger. 