### PR TITLE
filter functions for Bragg disk detection

### DIFF
--- a/py4DSTEM/process/diskdetection/diskdetection.py
+++ b/py4DSTEM/process/diskdetection/diskdetection.py
@@ -281,7 +281,6 @@ def find_Bragg_disks_selected(datacube, probe, Rx, Ry,
     t0 = time()
     for i in range(len(Rx)):
         DP = datacube.data[Rx[i],Ry[i],:,:] 
-
         peaks.append(_find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
                                                    corrPower = corrPower,
                                                    sigma = sigma,

--- a/py4DSTEM/process/diskdetection/diskdetection.py
+++ b/py4DSTEM/process/diskdetection/diskdetection.py
@@ -14,7 +14,7 @@ from ...io.datastructure import PointList, PointListArray
 from ..utils import get_cross_correlation_fk, get_maxima_2D, print_progress_bar, upsampled_correlation
 from ..utils import tqdmnd
 
-def find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
+def _find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
                                   corrPower = 1,
                                   sigma = 2,
                                   edgeBoundary = 20,
@@ -24,6 +24,7 @@ def find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
                                   maxNumPeaks = 70,
                                   subpixel = 'multicorr',
                                   upsample_factor = 16,
+                                  filter_function = None,
                                   return_cc = False,
                                   peaks = None):
     """
@@ -70,6 +71,12 @@ def find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
                                             'multicorr': uses the multicorr algorithm with
                                                         DFT upsampling
         upsample_factor      (int) upsampling factor for subpixel fitting (only used when subpixel='multicorr')
+        filter_function      (callable: lambda or partial function of one argument) filtering function to apply
+                             to each diffraction pattern before peakfinding. must be a function of only
+                             one argument (the diffraction pattern) and able to be pickled by the dill library.
+                             This is useful for doing noise reduction or binning on the fly for memory mapped
+                             datasets or for parallel operation. The shape of the returned DP must match the shape
+                             of the probe kernel.
         return_cc            (bool) if True, return the cross correlation
         peaks                (PointList) For internal use.
                              If peaks is None, the PointList of peak positions is created here.
@@ -80,6 +87,8 @@ def find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
         peaks                (PointList) the Bragg peak positions and correlation intensities
     """
     assert subpixel in [ 'none', 'poly', 'multicorr' ], "Unrecognized subpixel option {}, subpixel must be 'none', 'poly', or 'multicorr'".format(subpixel)
+
+    DP = DP if filter_function is None else filter_function(DP)
 
     if subpixel == 'none':
         cc = get_cross_correlation_fk(DP, probe_kernel_FT, corrPower)
@@ -153,10 +162,11 @@ def find_Bragg_disks_single_DP(DP, probe_kernel,
                                maxNumPeaks = 70,
                                subpixel = 'multicorr',
                                upsample_factor = 16,
+                               filter_function = None,
                                return_cc = False):
     """
-    Identical to find_Bragg_disks_single_DP_FK, accept that this function accepts a probe_kernel in
-    real space, rather than Fourier space. For more info, see the find_Bragg_disks_single_DP_FK
+    Identical to _find_Bragg_disks_single_DP_FK, accept that this function accepts a probe_kernel in
+    real space, rather than Fourier space. For more info, see the _find_Bragg_disks_single_DP_FK
     documentation.
 
     Accepts:
@@ -180,14 +190,21 @@ def find_Bragg_disks_single_DP(DP, probe_kernel,
                                             'multicorr': uses the multicorr algorithm with
                                                         DFT upsampling
         upsample_factor      (int) upsampling factor for subpixel fitting (only used when subpixel='multicorr')
+        filter_function      (callable: lambda or partial function of one argument) filtering function to apply
+                             to each diffraction pattern before peakfinding. must be a function of only
+                             one argument (the diffraction pattern) and able to be pickled by the dill library.
+                             This is useful for doing noise reduction or binning on the fly for memory mapped
+                             datasets or for parallel operation. The shape of the returned DP must match the shape
+                             of the probe kernel.
         return_cc            (bool) if True, return the cross correlation
 
     Returns:
         peaks                (PointList) the Bragg peak positions and correlation intensities
 
     """
+    if filter_function: assert callable(filter_function), "filter_function must be callable"
     probe_kernel_FT = np.conj(np.fft.fft2(probe_kernel))
-    return find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
+    return _find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
                                          corrPower = corrPower,
                                          sigma = sigma,
                                          edgeBoundary = edgeBoundary,
@@ -197,6 +214,7 @@ def find_Bragg_disks_single_DP(DP, probe_kernel,
                                          maxNumPeaks = maxNumPeaks,
                                          subpixel = subpixel,
                                          upsample_factor = upsample_factor,
+                                         filter_function = filter_function,
                                          return_cc = return_cc)
 
 
@@ -209,7 +227,8 @@ def find_Bragg_disks_selected(datacube, probe, Rx, Ry,
                               minPeakSpacing = 60,
                               maxNumPeaks = 70,
                               subpixel = 'multicorr',
-                              upsample_factor = 16):
+                              upsample_factor = 16,
+                              filter_function = None):
     """
     Finds the Bragg disks in the diffraction patterns of datacube at scan positions (Rx,Ry) by
     cross, hybrid, or phase correlation with probe.
@@ -237,12 +256,19 @@ def find_Bragg_disks_selected(datacube, probe, Rx, Ry,
                                             'multicorr': uses the multicorr algorithm with
                                                         DFT upsampling
         upsample_factor      (int) upsampling factor for subpixel fitting (only used when subpixel='multicorr')
+        filter_function      (callable: lambda or partial function of one argument) filtering function to apply
+                             to each diffraction pattern before peakfinding. must be a function of only
+                             one argument (the diffraction pattern) and able to be pickled by the dill library.
+                             This is useful for doing noise reduction or binning on the fly for memory mapped
+                             datasets or for parallel operation. The shape of the returned DP must match the shape
+                             of the probe kernel.
 
     Returns:
         peaks                (n-tuple of PointLists, n=len(Rx)) the Bragg peak positions and
                              correlation intensities at each scan position (Rx,Ry)
     """
     assert(len(Rx)==len(Ry))
+    if filter_function: assert callable(filter_function), "filter_function must be callable"
     peaks = []
 
     # Get probe kernel in Fourier space
@@ -251,8 +277,9 @@ def find_Bragg_disks_selected(datacube, probe, Rx, Ry,
     # Loop over selected diffraction patterns
     t0 = time()
     for i in range(len(Rx)):
-        DP = datacube.data[Rx[i],Ry[i],:,:]
-        peaks.append(find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
+        DP = datacube.data[Rx[i],Ry[i],:,:] 
+
+        peaks.append(_find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
                                                    corrPower = corrPower,
                                                    sigma = sigma,
                                                    edgeBoundary = edgeBoundary,
@@ -261,7 +288,8 @@ def find_Bragg_disks_selected(datacube, probe, Rx, Ry,
                                                    minPeakSpacing = minPeakSpacing,
                                                    maxNumPeaks = maxNumPeaks,
                                                    subpixel = subpixel,
-                                                   upsample_factor = upsample_factor))
+                                                   upsample_factor = upsample_factor,
+                                                   filter_function = filter_function))
     t = time()-t0
     print("Analyzed {} diffraction patterns in {}h {}m {}s".format(len(Rx), int(t/3600),
                                                                    int((t%3600)/60), int(t%60)))
@@ -282,6 +310,7 @@ def find_Bragg_disks_serial(datacube, probe,
                             global_threshold = False,
                             minGlobalIntensity = 0.005,
                             metric = 'mean',
+                            filter_function = None,
                             verbose = False,
                             _qt_progress_bar = None):
     """
@@ -319,6 +348,12 @@ def find_Bragg_disks_serial(datacube, probe,
                                 to the median of the maximum intensity peaks in each diffraction pattern. 'manual' Allows the user to threshold
                                 based on a predetermined intensity value manually determined. In this case, minIntensity should be an int.
         verbose              (bool) if True, prints completion updates
+        filter_function      (callable: lambda or partial function of one argument) filtering function to apply
+                             to each diffraction pattern before peakfinding. must be a function of only
+                             one argument (the diffraction pattern) and able to be pickled by the dill library.
+                             This is useful for doing noise reduction or binning on the fly for memory mapped
+                             datasets or for parallel operation. The shape of the returned DP must match the shape
+                             of the probe kernel.
         _qt_progress_bar     (QProgressBar instance) used only by the GUI.
     
     Returns:
@@ -330,6 +365,11 @@ def find_Bragg_disks_serial(datacube, probe,
     # Make the peaks PointListArray
     coords = [('qx',float),('qy',float),('intensity',float)]
     peaks = PointListArray(coordinates=coords, shape=(datacube.R_Nx, datacube.R_Ny))
+
+    # check that the filtered DP is the right size for the probe kernel:
+    if filter_function: assert callable(filter_function), "filter_function must be callable"
+    DP = datacube.data[0,0,:,:] if filter_function is None else filter_function(datacube.data[0,0,:,:])
+    assert np.all(DP.shape == probe.shape), 'Probe kernel shape must match filtered DP shape'
 
     # Get the probe kernel FT
     probe_kernel_FT = np.conj(np.fft.fft2(probe))
@@ -344,7 +384,7 @@ def find_Bragg_disks_serial(datacube, probe,
             _qt_progress_bar.setValue(Rx*datacube.R_Ny+Ry+1)
             QApplication.processEvents()
         DP = datacube.data[Rx,Ry,:,:]
-        find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
+        _find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
                                       corrPower = corrPower,
                                       sigma = sigma,
                                       edgeBoundary = edgeBoundary,
@@ -354,6 +394,7 @@ def find_Bragg_disks_serial(datacube, probe,
                                       maxNumPeaks = maxNumPeaks,
                                       subpixel = subpixel,
                                       upsample_factor = upsample_factor,
+                                      filter_function = filter_function,
                                       peaks = peaks.get_pointlist(Rx,Ry))
     t = time()-t0
     print("Analyzed {} diffraction patterns in {}h {}m {}s".format(datacube.R_N, int(t/3600),
@@ -376,6 +417,7 @@ def find_Bragg_disks(datacube, probe,
                      subpixel = 'multicorr',
                      upsample_factor = 16,
                      verbose = False,
+                     filter_function = None,
                      _qt_progress_bar = None,
                      distributed = None):
     """
@@ -404,6 +446,13 @@ def find_Bragg_disks(datacube, probe,
                                                         DFT upsampling
         upsample_factor      (int) upsampling factor for subpixel fitting (only used when subpixel='multicorr')
         verbose              (bool) if True, prints completion updates for serial execution
+        filter_function      (callable: lambda or function of one argument) filtering function to apply
+                             to each diffraction pattern before peakfinding. must be a function of only
+                             one argument (the diffraction pattern) and able to be pickled by the dill library.
+                             This is useful for doing noise reduction or binning on the fly for memory mapped
+                             datasets or for parallel operation. The shape of the returned DP must match the shape
+                             of the probe kernel. When using distributed mode, the function must contain
+                             all its own imports.
         _qt_progress_bar     (QProgressBar instance) used only by the GUI for serial execution
         distributed          (dict) contains information for parallelprocessing using an IPyParallel
                              or Dask distributed cluster.  Valid keys are:
@@ -491,6 +540,7 @@ def find_Bragg_disks(datacube, probe,
             subpixel=subpixel,
             upsample_factor=upsample_factor,
             verbose=verbose,
+            filter_function=filter_function,
             _qt_progress_bar=_qt_progress_bar)
     elif isinstance(distributed, dict):
         connect, data_file, cluster_path = _parse_distributed(distributed)
@@ -510,6 +560,7 @@ def find_Bragg_disks(datacube, probe,
                 maxNumPeaks=maxNumPeaks,
                 subpixel=subpixel,
                 upsample_factor=upsample_factor,
+                filter_function=filter_function,
                 ipyparallel_client_file=connect,
                 data_file=data_file,
                 cluster_path=cluster_path
@@ -529,6 +580,7 @@ def find_Bragg_disks(datacube, probe,
                 maxNumPeaks=maxNumPeaks,
                 subpixel=subpixel,
                 upsample_factor=upsample_factor,
+                filter_function=filter_function,
                 dask_client=connect,
                 data_file=data_file,
                 cluster_path=cluster_path

--- a/py4DSTEM/process/diskdetection/diskdetection.py
+++ b/py4DSTEM/process/diskdetection/diskdetection.py
@@ -71,12 +71,13 @@ def _find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
                                             'multicorr': uses the multicorr algorithm with
                                                         DFT upsampling
         upsample_factor      (int) upsampling factor for subpixel fitting (only used when subpixel='multicorr')
-        filter_function      (callable: lambda or partial function of one argument) filtering function to apply
-                             to each diffraction pattern before peakfinding. must be a function of only
-                             one argument (the diffraction pattern) and able to be pickled by the dill library.
-                             This is useful for doing noise reduction or binning on the fly for memory mapped
-                             datasets or for parallel operation. The shape of the returned DP must match the shape
-                             of the probe kernel.
+        filter_function      (callable) filtering function to apply to each diffraction pattern before peakfinding. 
+                             Must be a function of only one argument (the diffraction pattern) and return
+                             the filtered diffraction pattern.
+                             The shape of the returned DP must match the shape of the probe kernel (but does
+                             not need to match the shape of the input diffraction pattern, e.g. the filter
+                             can be used to bin the diffraction pattern). If using distributed disk detection,
+                             the function must be able to be pickled with by dill. 
         return_cc            (bool) if True, return the cross correlation
         peaks                (PointList) For internal use.
                              If peaks is None, the PointList of peak positions is created here.
@@ -190,12 +191,13 @@ def find_Bragg_disks_single_DP(DP, probe_kernel,
                                             'multicorr': uses the multicorr algorithm with
                                                         DFT upsampling
         upsample_factor      (int) upsampling factor for subpixel fitting (only used when subpixel='multicorr')
-        filter_function      (callable: lambda or partial function of one argument) filtering function to apply
-                             to each diffraction pattern before peakfinding. must be a function of only
-                             one argument (the diffraction pattern) and able to be pickled by the dill library.
-                             This is useful for doing noise reduction or binning on the fly for memory mapped
-                             datasets or for parallel operation. The shape of the returned DP must match the shape
-                             of the probe kernel.
+        filter_function      (callable) filtering function to apply to each diffraction pattern before peakfinding. 
+                             Must be a function of only one argument (the diffraction pattern) and return
+                             the filtered diffraction pattern.
+                             The shape of the returned DP must match the shape of the probe kernel (but does
+                             not need to match the shape of the input diffraction pattern, e.g. the filter
+                             can be used to bin the diffraction pattern). If using distributed disk detection,
+                             the function must be able to be pickled with by dill. 
         return_cc            (bool) if True, return the cross correlation
 
     Returns:
@@ -256,12 +258,13 @@ def find_Bragg_disks_selected(datacube, probe, Rx, Ry,
                                             'multicorr': uses the multicorr algorithm with
                                                         DFT upsampling
         upsample_factor      (int) upsampling factor for subpixel fitting (only used when subpixel='multicorr')
-        filter_function      (callable: lambda or partial function of one argument) filtering function to apply
-                             to each diffraction pattern before peakfinding. must be a function of only
-                             one argument (the diffraction pattern) and able to be pickled by the dill library.
-                             This is useful for doing noise reduction or binning on the fly for memory mapped
-                             datasets or for parallel operation. The shape of the returned DP must match the shape
-                             of the probe kernel.
+        filter_function      (callable) filtering function to apply to each diffraction pattern before peakfinding. 
+                             Must be a function of only one argument (the diffraction pattern) and return
+                             the filtered diffraction pattern.
+                             The shape of the returned DP must match the shape of the probe kernel (but does
+                             not need to match the shape of the input diffraction pattern, e.g. the filter
+                             can be used to bin the diffraction pattern). If using distributed disk detection,
+                             the function must be able to be pickled with by dill. 
 
     Returns:
         peaks                (n-tuple of PointLists, n=len(Rx)) the Bragg peak positions and
@@ -348,12 +351,13 @@ def find_Bragg_disks_serial(datacube, probe,
                                 to the median of the maximum intensity peaks in each diffraction pattern. 'manual' Allows the user to threshold
                                 based on a predetermined intensity value manually determined. In this case, minIntensity should be an int.
         verbose              (bool) if True, prints completion updates
-        filter_function      (callable: lambda or partial function of one argument) filtering function to apply
-                             to each diffraction pattern before peakfinding. must be a function of only
-                             one argument (the diffraction pattern) and able to be pickled by the dill library.
-                             This is useful for doing noise reduction or binning on the fly for memory mapped
-                             datasets or for parallel operation. The shape of the returned DP must match the shape
-                             of the probe kernel.
+        filter_function      (callable) filtering function to apply to each diffraction pattern before peakfinding. 
+                             Must be a function of only one argument (the diffraction pattern) and return
+                             the filtered diffraction pattern.
+                             The shape of the returned DP must match the shape of the probe kernel (but does
+                             not need to match the shape of the input diffraction pattern, e.g. the filter
+                             can be used to bin the diffraction pattern). If using distributed disk detection,
+                             the function must be able to be pickled with by dill. 
         _qt_progress_bar     (QProgressBar instance) used only by the GUI.
     
     Returns:
@@ -446,13 +450,13 @@ def find_Bragg_disks(datacube, probe,
                                                         DFT upsampling
         upsample_factor      (int) upsampling factor for subpixel fitting (only used when subpixel='multicorr')
         verbose              (bool) if True, prints completion updates for serial execution
-        filter_function      (callable: lambda or function of one argument) filtering function to apply
-                             to each diffraction pattern before peakfinding. must be a function of only
-                             one argument (the diffraction pattern) and able to be pickled by the dill library.
-                             This is useful for doing noise reduction or binning on the fly for memory mapped
-                             datasets or for parallel operation. The shape of the returned DP must match the shape
-                             of the probe kernel. When using distributed mode, the function must contain
-                             all its own imports.
+        filter_function      (callable) filtering function to apply to each diffraction pattern before peakfinding. 
+                             Must be a function of only one argument (the diffraction pattern) and return
+                             the filtered diffraction pattern.
+                             The shape of the returned DP must match the shape of the probe kernel (but does
+                             not need to match the shape of the input diffraction pattern, e.g. the filter
+                             can be used to bin the diffraction pattern). If using distributed disk detection,
+                             the function must be able to be pickled with by dill. 
         _qt_progress_bar     (QProgressBar instance) used only by the GUI for serial execution
         distributed          (dict) contains information for parallelprocessing using an IPyParallel
                              or Dask distributed cluster.  Valid keys are:

--- a/py4DSTEM/process/diskdetection/diskdetection_parallel.py
+++ b/py4DSTEM/process/diskdetection/diskdetection_parallel.py
@@ -71,6 +71,13 @@ def _find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
                                             'multicorr': uses the multicorr algorithm with
                                                         DFT upsampling
         upsample_factor      (int) upsampling factor for subpixel fitting (only used when subpixel='multicorr')
+        filter_function      (callable) filtering function to apply to each diffraction pattern before peakfinding. 
+                             Must be a function of only one argument (the diffraction pattern) and return
+                             the filtered diffraction pattern.
+                             The shape of the returned DP must match the shape of the probe kernel (but does
+                             not need to match the shape of the input diffraction pattern, e.g. the filter
+                             can be used to bin the diffraction pattern). If using distributed disk detection,
+                             the function must be able to be pickled with by dill. 
         return_cc            (bool) if True, return the cross correlation
         peaks                (PointList) For internal use.
                              If peaks is None, the PointList of peak positions is created here.
@@ -226,6 +233,13 @@ def find_Bragg_disks_ipp(DP, probe,
                                            'multicorr': uses the multicorr algorithm with
                                                         DFT upsampling
         upsample_factor           (int) upsampling factor for subpixel fitting (only used when subpixel='multicorr')
+        filter_function      (callable) filtering function to apply to each diffraction pattern before peakfinding. 
+                             Must be a function of only one argument (the diffraction pattern) and return
+                             the filtered diffraction pattern.
+                             The shape of the returned DP must match the shape of the probe kernel (but does
+                             not need to match the shape of the input diffraction pattern, e.g. the filter
+                             can be used to bin the diffraction pattern). If using distributed disk detection,
+                             the function must be able to be pickled with by dill. 
         ipyparallel_client_file   (str) absolute path to ipyparallel client JSON file for connecting to a cluster
         data_file                 (str) absolute path to the data file containing the datacube for processing remotely
         cluster_path              (str) working directory for cluster processing, defaults to current directory
@@ -386,6 +400,13 @@ def find_Bragg_disks_dask(DP, probe,
                                             'multicorr': uses the multicorr algorithm with
                                                         DFT upsampling
         upsample_factor      (int) upsampling factor for subpixel fitting (only used when subpixel='multicorr')
+        filter_function      (callable) filtering function to apply to each diffraction pattern before peakfinding. 
+                             Must be a function of only one argument (the diffraction pattern) and return
+                             the filtered diffraction pattern.
+                             The shape of the returned DP must match the shape of the probe kernel (but does
+                             not need to match the shape of the input diffraction pattern, e.g. the filter
+                             can be used to bin the diffraction pattern). If using distributed disk detection,
+                             the function must be able to be pickled with by dill. 
         dask_client          (obj) dask client for connecting to a cluster
         data_file             (str) absolute path to the data file containing the datacube for processing remotely
         cluster_path         (str) working directory for cluster processing, defaults to current directory

--- a/py4DSTEM/process/utils/utils.py
+++ b/py4DSTEM/process/utils/utils.py
@@ -548,8 +548,14 @@ def get_voronoi_vertices(voronoi, nx, ny, dist=10):
 
     return vertex_list
 
-
-def foo():
-    """Test func."""
-    print('pass')
+def ewpc_lambda(Q_Nx,Q_Ny):
+    '''
+    Returns a lambda for comuting the exit wave power cepstrum of a diffraction pattern
+    using a Hanning window. This can be passed as the filter_function in the Bragg disk
+    detection functions (with the probe an array of ones) to find the lattice vectors 
+    by the EWPC method (but be careful as the lengths are now in realspace units!)
+    See https://arxiv.org/abs/1911.00984
+    '''
+    h = np.hanning(Q_Nx)[:,np.newaxis] * np.hanning(Q_Ny)[np.newaxis,:]
+    return lambda x: np.abs(np.fft.fftshift(np.fft.fft2(h*np.log(np.maximum(x,0.01)))))**2
 

--- a/py4DSTEM/process/utils/utils.py
+++ b/py4DSTEM/process/utils/utils.py
@@ -548,11 +548,11 @@ def get_voronoi_vertices(voronoi, nx, ny, dist=10):
 
     return vertex_list
 
-def ewpc_lambda(Q_Nx,Q_Ny):
+def get_ewpc_filter_function(Q_Nx, Q_Ny):
     '''
-    Returns a lambda for comuting the exit wave power cepstrum of a diffraction pattern
+    Returns a function for computing the exit wave power cepstrum of a diffraction pattern
     using a Hanning window. This can be passed as the filter_function in the Bragg disk
-    detection functions (with the probe an array of ones) to find the lattice vectors 
+    detection functions (with the probe an array of ones) to find the lattice vectors
     by the EWPC method (but be careful as the lengths are now in realspace units!)
     See https://arxiv.org/abs/1911.00984
     '''

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,10 @@ setup(
         'ipywidgets == 7.6.3',
         'tqdm == 4.46.1',
         'requests == 2.25.1',
-        'dill == 0.3.3'
         ],
     extras_require={
-        'ipyparallel': ['ipyparallel >= 6.2.4'],
-        'dask': ['dask >= 2.3.0', 'distributed >= 2.3.0']
+        'ipyparallel': ['ipyparallel >= 6.2.4', 'dill == 0.3.3'],
+        'dask': ['dask >= 2.3.0', 'distributed >= 2.3.0', 'dill == 0.3.3']
         },
     entry_points={
         'console_scripts': ['py4DSTEM=py4DSTEM.gui.runGUI:launch']

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
         'qtconsole == 4.7.7',
         'ipywidgets == 7.6.3',
         'tqdm == 4.46.1',
-        'requests == 2.25.1'
+        'requests == 2.25.1',
+        'dill == 0.3.3'
         ],
     extras_require={
         'ipyparallel': ['ipyparallel >= 6.2.4'],


### PR DESCRIPTION
This PR resurrects a focused subset of the changes originally proposed in PR #98, which was previously abandoned.

It adds an optional `filter_function` argument to the Bragg disk detection functions which operates on each DP immediately between slicing/loading the DP from the datacube and performing the cross-correlation. A salient example is for binning diffraction patterns on-the-fly before disk detection (which requires that the user supply a probe kernel of the appropriate size):

```python
# make a function that bins the DP by 4
binf = lambda x: py4DSTEM.process.utils.bin2D(x,4)

# the probe kernel must also be binned (if the sizes don't match an exception gets raised)
probe_kernel_binned = py4DSTEM.process.braggdiskdetection.get_probe_kernel(binf(probe))

######### find peaks ########

# Peak detection parameters
corrPower = 0.8
sigma = 2
edgeBoundary = 20
maxNumPeaks = 70
minPeakSpacing = 50
minRelativeIntensity = 0.001
subpixel = 'poly'

# Find peaks
peaks = py4DSTEM.process.diskdetection.find_Bragg_disks(dc, probe_kernel_binned,
                                  corrPower=corrPower,
                                  sigma=sigma,
                                  edgeBoundary=edgeBoundary,
                                  minRelativeIntensity=minRelativeIntensity,
                                  minPeakSpacing=minPeakSpacing,
                                  maxNumPeaks=maxNumPeaks,
                                  subpixel=subpixel,
                                  filter_function = binf)
```

In addition, the exit wave power cepstrum method can be applied using the newly added EWPC function in `utils`. Other potential uses are Sobel filtering, intensity normalization, background subtraction, etc.