### PR TITLE
Diskdetection

### DIFF
--- a/py4DSTEM/process/diskdetection/diskdetection.py
+++ b/py4DSTEM/process/diskdetection/diskdetection.py
@@ -110,7 +110,7 @@ def _find_Bragg_disks_single_DP_FK(DP, probe_kernel_FT,
                                                  minSpacing=minPeakSpacing,
                                                  maxNumPeaks=maxNumPeaks,
                                                  subpixel=subpixel,
-                                                 ccc = ccc,
+                                                 ar_FT = ccc,
                                                  upsample_factor = upsample_factor)
 
     # Make peaks PointList

--- a/py4DSTEM/process/utils/multicorr.py
+++ b/py4DSTEM/process/utils/multicorr.py
@@ -4,7 +4,7 @@ https://github.com/ercius/openNCEM/blob/master/ncempy/algo/multicorr.py
 
 modified by SEZ, May 2019 to integrate with py4DSTEM utility functions
  * rewrote upsampleFFT (previously did not work correctly)
- * modified upsampled_correlation to accept xyShift, the point around which to 
+ * modified upsampled_correlation to accept xyShift, the point around which to
  upsample the DFT
  * eliminated the factor-2 FFT upsample step in favor of using parabolic
  for first-pass subpixel (since parabolic is so fast)
@@ -19,19 +19,19 @@ def upsampled_correlation(imageCorr, upsampleFactor, xyShift):
 
     There are two approaches to Fourier upsampling for subpixel refinement: (a) one
     can pad an (appropriately shifted) FFT with zeros and take the inverse transform,
-    or (b) one can compute the DFT by matrix multiplication using modified 
+    or (b) one can compute the DFT by matrix multiplication using modified
     transformation matrices. The former approach is straightforward but requires
     performing the FFT algorithm (which is fast) on very large data. The latter method
     trades one speedup for a slowdown elsewhere: the matrix multiply steps are expensive
     but we operate on smaller matrices. Since we are only interested in a very small
     region of the FT around a peak of interest, we use the latter method to get
-    a substantial speedup and enormous decrease in memory requirement. This 
+    a substantial speedup and enormous decrease in memory requirement. This
     "DFT upsampling" approach computes the transformation matrices for the matrix-
     multiply DFT around a small 1.5px wide region in the original `imageCorr`.
 
-    Following the matrix multiply DFT we use parabolic subpixel fitting to 
+    Following the matrix multiply DFT we use parabolic subpixel fitting to
     get even more precision! (below 1/upsampleFactor pixels)
-    
+
     NOTE: previous versions of multiCorr operated in two steps: using the zero-
     padding upsample method for a first-pass factor-2 upsampling, followed by the
     DFT upsampling (at whatever user-specified factor). I have implemented it
@@ -45,22 +45,22 @@ def upsampled_correlation(imageCorr, upsampleFactor, xyShift):
 
 
     Accepts:
-        imageCorr : ndarray complex 
+        imageCorr : ndarray complex
             Complex product of the FFTs of the two images to be registered
             i.e. m = np.fft.fft2(DP) * probe_kernel_FT;
             imageCorr = np.abs(m)**(corrPower) * np.exp(1j*np.angle(m))
         upsampleFactor : int
-            Upsampling factor. Must be greater than 2. (To do upsampling 
+            Upsampling factor. Must be greater than 2. (To do upsampling
             with factor 2, use upsampleFFT, which is faster.)
         xyShift
-            Location in original image coordinates around which to upsample the 
+            Location in original image coordinates around which to upsample the
             FT. This should be given to exactly half-pixel precision to
             replicate the initial FFT step that this implementation skips
 
     Returns
     -------
         xyShift : 2-element np array
-            Refined location of the peak in image coordinates. 
+            Refined location of the peak in image coordinates.
     '''
 
     assert upsampleFactor > 2
@@ -72,7 +72,7 @@ def upsampled_correlation(imageCorr, upsampleFactor, xyShift):
 
     upsampleCenter = globalShift - upsampleFactor*xyShift
 
-    imageCorrUpsample = np.conj(dftUpsample(np.conj(imageCorr), upsampleFactor, upsampleCenter )) 
+    imageCorrUpsample = np.conj(dftUpsample(np.conj(imageCorr), upsampleFactor, upsampleCenter ))
 
     xySubShift = np.unravel_index(imageCorrUpsample.argmax(), imageCorrUpsample.shape)
 

--- a/py4DSTEM/process/utils/utils.py
+++ b/py4DSTEM/process/utils/utils.py
@@ -227,7 +227,7 @@ def get_maximal_points(ar):
 
 
 def get_maxima_2D(ar, sigma=0, edgeBoundary=0, minSpacing=0, minRelativeIntensity=0,
-                  relativeToPeak=0, maxNumPeaks=0, subpixel='poly', ccc=None, upsample_factor=16):
+                  relativeToPeak=0, maxNumPeaks=0, subpixel='poly', ar_FT=None, upsample_factor=16):
     """
     Finds the indices where the 2D array ar is a local maximum.
     Optional parameters allow blurring of the array and filtering of the output;
@@ -248,8 +248,10 @@ def get_maxima_2D(ar, sigma=0, edgeBoundary=0, minSpacing=0, minRelativeIntensit
                                                     (fairly fast but not very accurate)
                                                'multicorr': uses the multicorr algorithm with
                                                         DFT upsampling
-        ccc                     (None or complex array) required iff subpixel=='multicorr'; the
-                                complex cross correlation of the image should be passed here
+        ar_FT                   (None or complex array) if subpixel=='multicorr' the
+                                fourier transform of the image is required.  It may be
+                                passed here as a complex array.  Otherwise, if ar_FT is None,
+                                it is computed
         upsample_factor         (int) required iff subpixel=='multicorr'
 
     Returns
@@ -326,6 +328,8 @@ def get_maxima_2D(ar, sigma=0, edgeBoundary=0, minSpacing=0, minRelativeIntensit
                 maxima['intensity'][i] = linear_interpolation_2D(ar, maxima['x'][i], maxima['y'][i])
         # Further refinement with fourier upsampling
         if subpixel == 'multicorr':
+            if ar_FT is None:
+                ar_FT = np.fft.fft2(ar)
             for ipeak in range(len(maxima['x'])):
                 xyShift = np.array((maxima['x'][ipeak],maxima['y'][ipeak]))
                 # we actually have to lose some precision and go down to half-pixel
@@ -334,7 +338,7 @@ def get_maxima_2D(ar, sigma=0, edgeBoundary=0, minSpacing=0, minRelativeIntensit
                 xyShift[0] = np.round(xyShift[0] * 2) / 2
                 xyShift[1] = np.round(xyShift[1] * 2) / 2
 
-                subShift = upsampled_correlation(ccc,upsample_factor,xyShift)
+                subShift = upsampled_correlation(ar_FT,upsample_factor,xyShift)
                 maxima['x'][ipeak]=subShift[0]
                 maxima['y'][ipeak]=subShift[1]
 

--- a/py4DSTEM/process/utils/utils.py
+++ b/py4DSTEM/process/utils/utils.py
@@ -10,6 +10,8 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
 import matplotlib.font_manager as fm
 
+from .multicorr import upsampled_correlation
+
 try:
     from IPython.display import clear_output
 except ImportError:
@@ -161,26 +163,44 @@ def get_shifted_ar(ar, xshift, yshift):
     return shifted_ar
 
 
-def get_cross_correlation(ar, kernel, corrPower=1):
+def get_cross_correlation(ar, kernel, corrPower=1, returnval='cc'):
     """
     Calculates the cross correlation of ar with kernel.
     corrPower specifies the correlation type, where 1 is a cross correlation, 0 is a phase
     correlation, and values in between are hybrids.
+
+    The return value depends on the argument `returnval`:
+        if return=='cc' (default), returns the real part of the cross correlation in real
+        space.
+        if return=='fourier', returns the output in Fourier space, before taking the
+        inverse transform.
     """
-    m = np.fft.fft2(ar) * np.conj(np.fft.fft2(kernel))
-    return np.real(np.fft.ifft2(np.abs(m) ** (corrPower) * np.exp(1j * np.angle(m))))
+    assert(returnval in ('cc','fourier'))
+    fourierkernel = np.conj(np.fft.fft2(kernel))
+    return get_cross_correlation_fk(ar, fourierkernel, corrPower=corrPower, returnval=returnval)
 
 
-def get_cross_correlation_fk(ar, fourierkernel, corrPower=1):
+def get_cross_correlation_fk(ar, fourierkernel, corrPower=1, returnval='cc'):
     """
     Calculates the cross correlation of ar with fourierkernel.
     Here, fourierkernel = np.conj(np.fft.fft2(kernel)); speeds up computation when the same
     kernel is to be used for multiple cross correlations.
     corrPower specifies the correlation type, where 1 is a cross correlation, 0 is a phase
     correlation, and values in between are hybrids.
+
+    The return value depends on the argument `returnval`:
+        if return=='cc' (default), returns the real part of the cross correlation in real
+        space.
+        if return=='fourier', returns the output in Fourier space, before taking the
+        inverse transform.
     """
+    assert(returnval in ('cc','fourier'))
     m = np.fft.fft2(ar) * fourierkernel
-    return np.real(np.fft.ifft2(np.abs(m) ** (corrPower) * np.exp(1j * np.angle(m))))
+    ccc = np.abs(m)**(corrPower) * np.exp(1j*np.angle(m))
+    if returnval=='fourier':
+        return ccc
+    else:
+        return np.real(np.fft.ifft2(ccc))
 
 
 def get_CoM(ar):
@@ -207,7 +227,7 @@ def get_maximal_points(ar):
 
 
 def get_maxima_2D(ar, sigma=0, edgeBoundary=0, minSpacing=0, minRelativeIntensity=0,
-                  relativeToPeak=0, maxNumPeaks=0, subpixel=True):
+                  relativeToPeak=0, maxNumPeaks=0, subpixel='poly', ccc=None, upsample_factor=16):
     """
     Finds the indices where the 2D array ar is a local maximum.
     Optional parameters allow blurring of the array and filtering of the output;
@@ -223,14 +243,22 @@ def get_maxima_2D(ar, sigma=0, edgeBoundary=0, minSpacing=0, minRelativeIntensit
                                 relativeToPeak'th brightest maximum are removed
         relativeToPeak          (int) 0=brightest maximum. 1=next brightest, etc.
         maxNumPeaks             (int) return only the first maxNumPeaks maxima
-        subpixel                (bool) if False, return locally maximal pixels.
-                                if True, perform subpixel fitting
+        subpixel                (str)          'none': no subpixel fitting
+                                     (default) 'poly': polynomial interpolation of correlogram peaks
+                                                    (fairly fast but not very accurate)
+                                               'multicorr': uses the multicorr algorithm with
+                                                        DFT upsampling
+        ccc                     (None or complex array) required iff subpixel=='multicorr'; the
+                                complex cross correlation of the image should be passed here
+        upsample_factor         (int) required iff subpixel=='multicorr'
 
     Returns
         maxima_x                (ndarray) x-coords of the local maximum, sorted by intensity.
         maxima_y                (ndarray) y-coords of the local maximum, sorted by intensity.
         maxima_intensity        (ndarray) intensity of the local maxima
     """
+    assert subpixel in [ 'none', 'poly', 'multicorr' ], "Unrecognized subpixel option {}, subpixel must be 'none', 'poly', or 'multicorr'".format(subpixel)
+
     # Get maxima
     ar = gaussian_filter(ar, sigma)
     maxima_bool = get_maximal_points(ar)
@@ -281,8 +309,9 @@ def get_maxima_2D(ar, sigma=0, edgeBoundary=0, minSpacing=0, minRelativeIntensit
             if len(maxima) > maxNumPeaks:
                 maxima = maxima[:maxNumPeaks]
 
-        # Subpixel fitting - fit 1D parabolas in x and y to 3 points (maximum, +/- 1 pixel)
-        if subpixel is True:
+        # Subpixel fitting 
+        # For all subpixel fitting, first fit 1D parabolas in x and y to 3 points (maximum, +/- 1 pixel)
+        if subpixel != 'none':
             for i in range(len(maxima)):
                 Ix1_ = ar[int(maxima['x'][i]) - 1, int(maxima['y'][i])]
                 Ix0 = ar[int(maxima['x'][i]), int(maxima['y'][i])]
@@ -295,6 +324,19 @@ def get_maxima_2D(ar, sigma=0, edgeBoundary=0, minSpacing=0, minRelativeIntensit
                 maxima['x'][i] += deltax
                 maxima['y'][i] += deltay
                 maxima['intensity'][i] = linear_interpolation_2D(ar, maxima['x'][i], maxima['y'][i])
+        # Further refinement with fourier upsampling
+        if subpixel == 'multicorr':
+            for ipeak in range(len(maxima['x'])):
+                xyShift = np.array((maxima['x'][ipeak],maxima['y'][ipeak]))
+                # we actually have to lose some precision and go down to half-pixel
+                # accuracy. this could also be done by a single upsampling at factor 2
+                # instead of get_maxima_2D.
+                xyShift[0] = np.round(xyShift[0] * 2) / 2
+                xyShift[1] = np.round(xyShift[1] * 2) / 2
+
+                subShift = upsampled_correlation(ccc,upsample_factor,xyShift)
+                maxima['x'][ipeak]=subShift[0]
+                maxima['y'][ipeak]=subShift[1]
 
     return maxima['x'], maxima['y'], maxima['intensity']
 


### PR DESCRIPTION
This PR
- simplifies the logic in disk detection (`_find_Bragg_disks_single_DP_FK`) so that all subpixel options make the same function calls
- edits `utils.get_crosscorrelation` and `utils.get_crosscorrelation_fk` to call the same functional code
- edits the `utils.get_crosscorrelation*` fns to optionally return the complex valued fourier transform of the cc, instead of the cc itself, to allow sped up disk detection computation when `subpixel='multicorr'`
- enables `subpixel='multicorr'` subpixel correlation within `utils.get_maxima_2D`