### PR TITLE
Fixing some .show inconsistencies

### DIFF
--- a/py4DSTEM/process/calibration/origin.py
+++ b/py4DSTEM/process/calibration/origin.py
@@ -311,7 +311,8 @@ def center_braggpeaks(braggpeaks, qx0=None, qy0=None, coords=None, name=None):
 
     Accepts:
         braggpeaks  (PointListArray) the detected, unshifted bragg peaks
-        qx0,qy0     ((R_Nx,R_Ny)-shaped arrays) the position of the origin
+        qx0,qy0     ((R_Nx,R_Ny)-shaped arrays) the position of the origin,
+                    or scalar values for constant origin position.
         coords      (Coordinates) an object containing the origin positions
         name        (str, optional) a name for the returned PointListArray.
                     If unspecified, takes the old PLA name, removes '_raw'
@@ -334,12 +335,19 @@ def center_braggpeaks(braggpeaks, qx0=None, qy0=None, coords=None, name=None):
     assert isinstance(name,str)
     braggpeaks_centered = braggpeaks.copy(name=name)
 
-    for Rx in range(braggpeaks_centered.shape[0]):
-        for Ry in range(braggpeaks_centered.shape[1]):
-            pointlist = braggpeaks_centered.get_pointlist(Rx,Ry)
-            qx,qy = qx0[Rx,Ry],qy0[Rx,Ry]
-            pointlist.data['qx'] -= qx
-            pointlist.data['qy'] -= qy
+    if np.isscalar(qx0) & np.isscalar(qy0):
+        for Rx in range(braggpeaks_centered.shape[0]):
+            for Ry in range(braggpeaks_centered.shape[1]):
+                pointlist = braggpeaks_centered.get_pointlist(Rx,Ry)
+                pointlist.data['qx'] -= qx0
+                pointlist.data['qy'] -= qy0        
+    else:
+        for Rx in range(braggpeaks_centered.shape[0]):
+            for Ry in range(braggpeaks_centered.shape[1]):
+                pointlist = braggpeaks_centered.get_pointlist(Rx,Ry)
+                qx,qy = qx0[Rx,Ry],qy0[Rx,Ry]
+                pointlist.data['qx'] -= qx
+                pointlist.data['qy'] -= qy
 
     return braggpeaks_centered
 

--- a/py4DSTEM/process/latticevectors/fit.py
+++ b/py4DSTEM/process/latticevectors/fit.py
@@ -30,12 +30,14 @@ def fit_lattice_vectors(braggpeaks, x0=0, y0=0, minNumPeaks=5):
         error               (float) the fit error
     """
     assert isinstance(braggpeaks, PointList)
-    assert np.all([name in braggpeaks.dtype.names for name in ('qx','qy','intensity','h','k','index_mask')])
+    # assert np.all([name in braggpeaks.dtype.names for name in ('qx','qy','intensity','h','k','index_mask')])
+    assert np.all([name in braggpeaks.dtype.names for name in ('qx','qy','intensity','h','k')])
     braggpeaks = braggpeaks.copy()
 
     # Remove unindexed peaks
-    deletemask = braggpeaks.data['index_mask'] == False
-    braggpeaks.remove_points(deletemask)
+    if 'index_mask' in braggpeaks.data:
+        deletemask = braggpeaks.data['index_mask'] == False
+        braggpeaks.remove_points(deletemask)
 
     # Check to ensure enough peaks are present
     if braggpeaks.length < minNumPeaks:
@@ -93,7 +95,8 @@ def fit_lattice_vectors_all_DPs(braggpeaks, x0=0, y0=0, minNumPeaks=5):
         g1g2_map.slices['mask']   1 for successful fits, 0 for unsuccessful fits
     """
     assert isinstance(braggpeaks, PointListArray)
-    assert np.all([name in braggpeaks.dtype.names for name in ('qx','qy','intensity','h','k','index_mask')])
+    # assert np.all([name in braggpeaks.dtype.names for name in ('qx','qy','intensity','h','k','index_mask')])
+    assert np.all([name in braggpeaks.dtype.names for name in ('qx','qy','intensity','h','k')])
 
     # Make RealSlice to contain outputs
     slicelabels = ('x0','y0','g1x','g1y','g2x','g2y','error','mask')

--- a/py4DSTEM/visualize/overlay.py
+++ b/py4DSTEM/visualize/overlay.py
@@ -475,12 +475,12 @@ def add_bragg_index_labels(ax,d):
         h,k = braggdirections.data['h'][i],braggdirections.data['k'][i]
         h = str(h) if h>=0 else '$\overline{{{}}}$'.format(np.abs(h))
         k = str(k) if k>=0 else '$\overline{{{}}}$'.format(np.abs(k))
-        s = h+k
+        s = h+','+k
         if include_l:
             l = braggdirections.data['l'][i]
             l = str(l) if l>=0 else '$\overline{{{}}}$'.format(np.abs(l))
             s += l
-        ax.text(y,x,s,color=color,size=size,ha='center',va='center')
+        ax.text(y,x,s,color=color,size=size,ha='center',va='bottom')
 
     return
 

--- a/py4DSTEM/visualize/show.py
+++ b/py4DSTEM/visualize/show.py
@@ -161,17 +161,21 @@ def show(ar,figsize=(8,8),cmap='gray',scaling='none',clipvals='minmax',
         _mask = ar>0
         _ar = np.zeros_like(ar.data,dtype=float)
         _ar[_mask] = np.log(ar[_mask])
-        if min != 0:
-            min = np.log(min)
-        else:
-            min = np.min(_ar[_mask])
-        max = np.log(max)
+        if min != None:
+            if min != 0:
+                min = np.log(min)
+            else:
+                min = np.min(_ar[_mask])
+        if max != None:
+            max = np.log(max)
     elif scaling == 'power':
         _mask = ar>0
         _ar = np.zeros_like(ar.data,dtype=float)
         _ar[_mask] = np.power(ar[_mask],power)
-        min = np.power(min,power)
-        max = np.power(max,power)
+        if min != None:
+            min = np.power(min,power)
+        if max != None:
+            max = np.power(max,power)
     else:
         raise Exception
     _ar = np.ma.array(data=_ar.data,mask=np.logical_and(ar.mask==False,_mask)==False)

--- a/py4DSTEM/visualize/show.py
+++ b/py4DSTEM/visualize/show.py
@@ -161,10 +161,17 @@ def show(ar,figsize=(8,8),cmap='gray',scaling='none',clipvals='minmax',
         _mask = ar>0
         _ar = np.zeros_like(ar.data,dtype=float)
         _ar[_mask] = np.log(ar[_mask])
+        if min != 0:
+            min = np.log(min)
+        else:
+            min = np.min(_ar[_mask])
+        max = np.log(max)
     elif scaling == 'power':
         _mask = ar>0
         _ar = np.zeros_like(ar.data,dtype=float)
         _ar[_mask] = np.power(ar[_mask],power)
+        min = np.power(min,power)
+        max = np.power(max,power)
     else:
         raise Exception
     _ar = np.ma.array(data=_ar.data,mask=np.logical_and(ar.mask==False,_mask)==False)
@@ -178,7 +185,7 @@ def show(ar,figsize=(8,8),cmap='gray',scaling='none',clipvals='minmax',
     elif clipvals == 'std':
         assert min is not None and max is not None
         m,s = np.median(_ar),np.std(_ar)
-        vmin = m - min*s
+        vmin = m + min*s
         vmax = m + max*s
     elif clipvals == 'centered':
         c = np.mean(_ar) if min is None else min

--- a/py4DSTEM/visualize/show.py
+++ b/py4DSTEM/visualize/show.py
@@ -162,7 +162,7 @@ def show(ar,figsize=(8,8),cmap='gray',scaling='none',clipvals='minmax',
         _ar = np.zeros_like(ar.data,dtype=float)
         _ar[_mask] = np.log(ar[_mask])
         if min != None:
-            if min != 0:
+            if min > 0:
                 min = np.log(min)
             else:
                 min = np.min(_ar[_mask])

--- a/py4DSTEM/visualize/vis_special.py
+++ b/py4DSTEM/visualize/vis_special.py
@@ -309,7 +309,8 @@ def show_strain(strainmap,vrange_exx,vrange_theta,vrange_exy=None,vrange_eyy=Non
                                     ('% ',' %','% ',r' $^\circ$')):
             if show_cbar:
                 cb = plt.colorbar(cax,cax=cbax,ticks=np.linspace(vmin,vmax,5,endpoint=True))
-                cb.ax.set_yticklabels(['{}'.format(val) for val in np.linspace(100*vmin,100*vmax,5,endpoint=True)],size=ticklabelsize)
+                cb.ax.set_yticklabels(['{}'.format(val) \
+                    for val in np.round(np.linspace(100*vmin,100*vmax,5,endpoint=True)*100)/100],size=ticklabelsize)
                 cbax.yaxis.set_ticks_position(tickside)
                 cbax.set_ylabel(tickunits,size=unitlabelsize,rotation=0)
                 cbax.yaxis.set_label_position(tickside)

--- a/py4DSTEM/visualize/vis_special.py
+++ b/py4DSTEM/visualize/vis_special.py
@@ -232,7 +232,7 @@ def show_class_BPs_grid(ar,H,W,x,y,get_s,s2,color='r',color2='y',returnfig=False
 
 def show_strain(strainmap,vrange_exx,vrange_theta,vrange_exy=None,vrange_eyy=None,
                 bkgrd=True,show_cbars=('exx','eyy','exy','theta'),
-                titlesize=24,ticklabelsize=16,unitlabelsize=24,
+                titlesize=24,ticklabelsize=16,ticknumber=5,unitlabelsize=24,
                 show_axes=True,axes_x0=0,axes_y0=0,xaxis_x=1,xaxis_y=0,axes_length=10,
                 axes_width=1,axes_color='r',xaxis_space='Q',labelaxes=True,QR_rotation=0,
                 axes_labelsize=12,axes_labelcolor='r',axes_plots=('exx'),cmap='RdBu_r',
@@ -308,9 +308,9 @@ def show_strain(strainmap,vrange_exx,vrange_theta,vrange_exy=None,vrange_eyy=Non
                                     ('left','right','left','right'),
                                     ('% ',' %','% ',r' $^\circ$')):
             if show_cbar:
-                cb = plt.colorbar(cax,cax=cbax,ticks=np.linspace(vmin,vmax,5,endpoint=True))
+                cb = plt.colorbar(cax,cax=cbax,ticks=np.linspace(vmin,vmax,ticknumber,endpoint=True))
                 cb.ax.set_yticklabels(['{}'.format(val) \
-                    for val in np.round(np.linspace(100*vmin,100*vmax,5,endpoint=True)*100)/100],size=ticklabelsize)
+                    for val in np.round(np.linspace(100*vmin,100*vmax,ticknumber,endpoint=True)*100)/100],size=ticklabelsize)
                 cbax.yaxis.set_ticks_position(tickside)
                 cbax.set_ylabel(tickunits,size=unitlabelsize,rotation=0)
                 cbax.yaxis.set_label_position(tickside)


### PR DESCRIPTION
When selecting different image scaling modes, such as manual, std, log or power, we want to keep the intensity range / clipvals as self consistent as possible.

For example before this update:
![image](https://user-images.githubusercontent.com/796309/121963899-97d60d00-cd1f-11eb-96d6-65dda369cb9d.png)

And after this update:
![image](https://user-images.githubusercontent.com/796309/121963917-9e648480-cd1f-11eb-9b02-5586135537c1.png)

Note how we can keep the intensity ranges the same and produce the same images for "manual" and "std."  Similar logic has been applied to log and power.  Finally, if the min=0 setting is used for log scaling, this value is instead reset to the minimum value of the image after taking the log.