### PR TITLE
Add support for reading EMD using MEMMAP

### DIFF
--- a/py4DSTEM/io/datastructure/datacube.py
+++ b/py4DSTEM/io/datastructure/datacube.py
@@ -290,12 +290,10 @@ def get_datacube_from_grp(g,mem='RAM',binfactor=1,bindtype=None):
     # TODO: add binning
     if mem == 'MEMMAP':
         h5_filename = g.file.filename
-        with emd.fileEMD(h5_filename) as emdF:
-            emd_memmap = emdF.get_memmap(0)
-            dataset = emd_memmap[0]
-            mm = np.memmap(h5_filename, shape=dataset.shape, dtype=dataset.dtype, offset=dataset.id.get_offset())
-            name = dataset.parent.name.split('/')[-1]
-            return DataCube(data=mm, name=name)
+        emdF = emd.fileEMD(h5_filename)
+        dataset, dims = emdF.get_memmap(0)
+        name = dataset.parent.name.split('/')[-1]
+        return DataCube(data=dataset, name=name, nothing=emdF)
     data = np.array(g['data'])
     name = g.name.split('/')[-1]
     return DataCube(data=data,name=name)

--- a/py4DSTEM/test/test_io/test_datastructure/test_datacube.py
+++ b/py4DSTEM/test/test_io/test_datastructure/test_datacube.py
@@ -1,0 +1,51 @@
+import unittest
+import os
+import h5py
+import numpy as np
+
+from tempfile import mkdtemp
+from shutil import rmtree
+
+from py4DSTEM.io.datastructure.datacube import get_datacube_from_grp
+
+class Test(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = mkdtemp()
+        self.h5_file = h5py.File(os.path.join(self.tmpdir, 'test.h5'), 'w')
+        (self.h5_file
+         .create_group('4DSTEM_experiment')
+         .create_group('data')
+         .create_group('datacubes')
+         .create_group('datacube_0')
+         .create_dataset('data', data=np.ones(shape=(2,2,3,3)), dtype='uint8')
+        )
+        self.datacube = self.h5_file['4DSTEM_experiment']['data']['datacubes']['datacube_0']
+        self.datacube.attrs.create('emd_group_type', 1)
+        dim1 = self.datacube.create_dataset('dim1', shape=(2,), dtype='uint8')
+        dim1.attrs.create('name', np.string_("R_x"))
+        dim1.attrs.create('units', np.string_("[pix]"))
+        dim2 = self.datacube.create_dataset('dim2', shape=(2,), dtype='uint8')
+        dim2.attrs.create('name', np.string_("R_y"))
+        dim2.attrs.create('units', np.string_("[pix]"))
+        dim3 = self.datacube.create_dataset('dim3', shape=(3,), dtype='uint8')
+        dim3.attrs.create('name', np.string_("Q_x"))
+        dim3.attrs.create('units', np.string_("[pix]"))
+        dim4 = self.datacube.create_dataset('dim4', shape=(3,), dtype='uint8')
+        dim4.attrs.create('name', np.string_("Q_y"))
+        dim4.attrs.create('units', np.string_("[pix]"))
+        
+
+    def testH5Memmap(self):
+        memmap_datacube = get_datacube_from_grp(self.datacube, mem='MEMMAP')
+        ram_datacube = get_datacube_from_grp(self.datacube)
+        self.assertTrue(np.array_equal(memmap_datacube.data, ram_datacube.data))
+        self.assertTrue(memmap_datacube.name == ram_datacube.name)
+
+    def tearDown(self):
+        self.h5_file.close()
+        rmtree(self.tmpdir)
+
+
+if __name__=='__main__':
+    unittest.main()

--- a/py4DSTEM/test/test_io/test_datastructure/test_utils.py
+++ b/py4DSTEM/test/test_io/test_datastructure/test_utils.py
@@ -1,0 +1,28 @@
+import os
+import h5py
+import numpy as np
+
+def create_EMD(file_name, tmpdir, chunks=None):
+        h5_file = h5py.File(os.path.join(tmpdir, file_name), 'w')
+        (h5_file
+         .create_group('4DSTEM_experiment')
+         .create_group('data')
+         .create_group('datacubes')
+         .create_group('datacube_0')
+         .create_dataset('data', data=np.ones(shape=(2,2,3,3)), dtype='uint8', chunks=chunks)
+        )
+        datacube = h5_file['4DSTEM_experiment']['data']['datacubes']['datacube_0']
+        datacube.attrs.create('emd_group_type', 1)
+        dim1 = datacube.create_dataset('dim1', shape=(2,), dtype='uint8')
+        dim1.attrs.create('name', np.string_("R_x"))
+        dim1.attrs.create('units', np.string_("[pix]"))
+        dim2 = datacube.create_dataset('dim2', shape=(2,), dtype='uint8')
+        dim2.attrs.create('name', np.string_("R_y"))
+        dim2.attrs.create('units', np.string_("[pix]"))
+        dim3 = datacube.create_dataset('dim3', shape=(3,), dtype='uint8')
+        dim3.attrs.create('name', np.string_("Q_x"))
+        dim3.attrs.create('units', np.string_("[pix]"))
+        dim4 = datacube.create_dataset('dim4', shape=(3,), dtype='uint8')
+        dim4.attrs.create('name', np.string_("Q_y"))
+        dim4.attrs.create('units', np.string_("[pix]"))
+        return h5_file, datacube


### PR DESCRIPTION
Hello! I noticed there was a TODO to add MEMMAP support for EMD datasets as well. As far as I could tell, it didn't seem like it was supported quite yet.

I made an attempt to do so by mirroring the logic that exists for read_dm.py.

## Testing
- This was tested using ~32 and ~70GB h5 files on a 48GB RAM computer and worked pretty well. 
- I tested it with [the provided small h5 file](https://drive.google.com/file/d/12Q3T57x9N2vkyY0llqBLKn_0JPurQM6Y/view?usp=sharing) and had success there. 
- I added a small unit test to note that there shouldn't be regression: DataCube result should be the same whether using MEMMAP or RAM.

I'm less familiar with the various technical use cases of the library and whether we'd need to generalize this approach further, but  I'm happy to continue to work on the PR and address any comments that come up!

Thank you for your time!