### PR TITLE
Add reader for EMPAD raw files

### DIFF
--- a/py4DSTEM/io/nonnative/__init__.py
+++ b/py4DSTEM/io/nonnative/__init__.py
@@ -1,2 +1,3 @@
 from .read_dm import *
 from .read_K2 import read_gatan_K2_bin
+from .empad import read_empad

--- a/py4DSTEM/io/nonnative/empad.py
+++ b/py4DSTEM/io/nonnative/empad.py
@@ -1,5 +1,5 @@
 # Reads an EMPAD file
-# 
+#
 # Created on Tue Jan 15 13:06:03 2019
 # @author: percius
 # Edited on 20190409 by bsavitzky and rdhall
@@ -7,6 +7,7 @@
 
 import numpy as np
 from pathlib import Path
+
 
 def read_empad(filename):
     """
@@ -31,22 +32,21 @@ def read_empad(filename):
     fPath = Path(filename)
 
     # Parse the EMPAD metadata for first and last images
-    empadDTYPE = np.dtype([('data','16384float32'),('metadata','256float32')])
-    with open(fPath,'rb') as fid:
-        imFirst = np.fromfile(fid,dtype=empadDTYPE,count=1)
-        fid.seek(-128*130*4,2)
-        imLast = np.fromfile(fid,dtype=empadDTYPE,count=1)
+    empadDTYPE = np.dtype([("data", "16384float32"), ("metadata", "256float32")])
+    with open(fPath, "rb") as fid:
+        imFirst = np.fromfile(fid, dtype=empadDTYPE, count=1)
+        fid.seek(-128 * 130 * 4, 2)
+        imLast = np.fromfile(fid, dtype=empadDTYPE, count=1)
 
     # Get the scan shape
-    shape0 = imFirst['metadata'][0][128+12:128+16]
-    shape1 = imLast['metadata'][0][128+12:128+16]
-    kShape = shape0[2:4]                        # detector shape
-    rShape = 1 + shape1[0:2] - shape0[0:2]      # scan shape
+    shape0 = imFirst["metadata"][0][128 + 12 : 128 + 16]
+    shape1 = imLast["metadata"][0][128 + 12 : 128 + 16]
+    kShape = shape0[2:4]  # detector shape
+    rShape = 1 + shape1[0:2] - shape0[0:2]  # scan shape
 
     # Load the full data set
-    with open(fPath,'rb') as fid:
-        data = np.fromfile(fid,np.float32)
+    with open(fPath, "rb") as fid:
+        data = np.fromfile(fid, np.float32)
         data = np.reshape(data, (int(rShape[0]), int(rShape[1]), row, col))
 
     return data
-

--- a/py4DSTEM/io/nonnative/empad.py
+++ b/py4DSTEM/io/nonnative/empad.py
@@ -79,7 +79,7 @@ def read_empad(filename, mem="RAM", binfactor=1, metadata=False, **kwargs):
             R_Nx, R_Ny, desc="Binning data", unit="DP", unit_scale=True
         ):
             data[Rx, Ry, :, :] = bin2D(
-                memmap[Rx, Ry, :, :,], binfactor, dtype=np.float32
+                memmap[Rx, Ry, :, :], binfactor, dtype=np.float32
             )
     else:
         # memory mapping + bin-on-load is not supported

--- a/py4DSTEM/io/nonnative/empad.py
+++ b/py4DSTEM/io/nonnative/empad.py
@@ -10,9 +10,6 @@ from pathlib import Path
 from ..datastructure import DataCube
 from ...process.utils import bin2D, tqdmnd
 
-from pdb import set_trace
-
-
 def read_empad(filename, mem="RAM", binfactor=1, metadata=False, **kwargs):
     """
     Reads the EMPAD file at filename, returning a DataCube.
@@ -28,7 +25,6 @@ def read_empad(filename, mem="RAM", binfactor=1, metadata=False, **kwargs):
     Returns:
         data        (DataCube) the 4D datacube, excluding the metadata rows.
     """
-
     assert(isinstance(filename, (str, Path))), "Error: filepath fp must be a string or pathlib.Path"
     assert(mem in ['RAM', 'MEMMAP']), 'Error: argument mem must be either "RAM" or "MEMMAP"'
     assert(isinstance(binfactor, int)), "Error: argument binfactor must be an integer"
@@ -50,13 +46,12 @@ def read_empad(filename, mem="RAM", binfactor=1, metadata=False, **kwargs):
     shape0 = imFirst["metadata"][0][128 + 12 : 128 + 16]
     shape1 = imLast["metadata"][0][128 + 12 : 128 + 16]
     rShape = 1 + shape1[0:2] - shape0[0:2]  # scan shape
-
     data_shape = (int(rShape[0]), int(rShape[1]), row, col)
 
+    # Load the data
     if (mem, binfactor) == ("RAM", 1):
         with open(fPath, "rb") as fid:
             data = np.fromfile(fid, np.float32).reshape(data_shape)[:, :, :128, :]
-
     elif (mem, binfactor) == ("MEMMAP", 1):
         data = np.memmap(fPath, dtype=np.float32, mode="r", shape=data_shape)[
             :, :, :128, :

--- a/py4DSTEM/io/nonnative/empad.py
+++ b/py4DSTEM/io/nonnative/empad.py
@@ -15,30 +15,25 @@ from pdb import set_trace
 
 def read_empad(filename, mem="RAM", binfactor=1, metadata=False, **kwargs):
     """
-    Reads the EMPAD file at filename, returning a numpy array.
+    Reads the EMPAD file at filename, returning a DataCube.
 
     EMPAD files are shaped as 130x128 arrays, consisting of 128x128 arrays of data followed by
     two rows of metadata.  For each frame, its position in the scan is embedded in the metadata.
     By extracting the scan position of the first and last frames, the function determines the scan
-    size. Then, the full dataset is loaded.
-
-    Note that the output of this function is a datacube which includes the 2 rows of metadata.
+    size. Then, the full dataset is loaded and cropped to the 128x128 valid region.
 
     Accepts:
-        filename    (str) path to the empad file
+        filename    (str) path to the EMPAD file
 
     Returns:
-        data        (ndarray) the 4D datacube, including the metadata.
-                    raw data only can be accessed data[:,:,:128,:]
+        data        (DataCube) the 4D datacube, excluding the metadata rows.
     """
 
-    # fmt: off
     assert(isinstance(filename, (str, Path))), "Error: filepath fp must be a string or pathlib.Path"
     assert(mem in ['RAM', 'MEMMAP']), 'Error: argument mem must be either "RAM" or "MEMMAP"'
     assert(isinstance(binfactor, int)), "Error: argument binfactor must be an integer"
     assert(binfactor >= 1), "Error: binfactor must be >= 1"
     assert(metadata is False), "Error: EMPAD Reader does not support metadata."
-    # fmt: on
 
     row = 130
     col = 128
@@ -54,7 +49,6 @@ def read_empad(filename, mem="RAM", binfactor=1, metadata=False, **kwargs):
     # Get the scan shape
     shape0 = imFirst["metadata"][0][128 + 12 : 128 + 16]
     shape1 = imLast["metadata"][0][128 + 12 : 128 + 16]
-    # kShape = shape0[2:4]  # detector shape (should always be row x col)
     rShape = 1 + shape1[0:2] - shape0[0:2]  # scan shape
 
     data_shape = (int(rShape[0]), int(rShape[1]), row, col)

--- a/py4DSTEM/io/nonnative/empad.py
+++ b/py4DSTEM/io/nonnative/empad.py
@@ -1,0 +1,52 @@
+# Reads an EMPAD file
+# 
+# Created on Tue Jan 15 13:06:03 2019
+# @author: percius
+# Edited on 20190409 by bsavitzky and rdhall
+# Edited on 20210611 by sez
+
+import numpy as np
+from pathlib import Path
+
+def read_empad(filename):
+    """
+    Reads the EMPAD file at filename, returning a numpy array.
+
+    EMPAD files are shaped as 130x128 arrays, consisting of 128x128 arrays of data followed by
+    two rows of metadata.  For each frame, its position in the scan is embedded in the metadata.
+    By extracting the scan position of the first and last frames, the function determines the scan
+    size. Then, the full dataset is loaded.
+
+    Note that the output of this function is a datacube which includes the 2 rows of metadata.
+
+    Accepts:
+        filename    (str) path to the empad file
+
+    Returns:
+        data        (ndarray) the 4D datacube, including the metadata.
+                    raw data only can be accessed data[:,:,:128,:]
+    """
+    row = 130
+    col = 128
+    fPath = Path(filename)
+
+    # Parse the EMPAD metadata for first and last images
+    empadDTYPE = np.dtype([('data','16384float32'),('metadata','256float32')])
+    with open(fPath,'rb') as fid:
+        imFirst = np.fromfile(fid,dtype=empadDTYPE,count=1)
+        fid.seek(-128*130*4,2)
+        imLast = np.fromfile(fid,dtype=empadDTYPE,count=1)
+
+    # Get the scan shape
+    shape0 = imFirst['metadata'][0][128+12:128+16]
+    shape1 = imLast['metadata'][0][128+12:128+16]
+    kShape = shape0[2:4]                        # detector shape
+    rShape = 1 + shape1[0:2] - shape0[0:2]      # scan shape
+
+    # Load the full data set
+    with open(fPath,'rb') as fid:
+        data = np.fromfile(fid,np.float32)
+        data = np.reshape(data, (int(rShape[0]), int(rShape[1]), row, col))
+
+    return data
+

--- a/py4DSTEM/io/read.py
+++ b/py4DSTEM/io/read.py
@@ -142,8 +142,7 @@ def parse_filetype(fp):
             )
     elif fext in [".dm", ".dm3", ".dm4", ".DM", ".DM3", ".DM4"]:
         return "dm"
-    elif fext in [".empad"]:
-        # TK TODO
+    elif fext in [".raw"]:
         return "empad"
     elif fext in [".mrc"]:
         # TK TODO


### PR DESCRIPTION
This PR adds the ability to read files from the original EMPAD (support for EMPAD 2 is unknown, as I don't have any test files for that). The reader supports reading into memory, memory-mapping, and bin-on-read to RAM. 

Metadata is not supported as there is no meaningful metadata that I am aware of in the file format. (A separate XML file is used for that metadata, but I have not added support for reading from that file. Perhaps this would be handled through a `kwarg` like `metadata_file` if we chose to implement it, since in the examples I've seen the XML does not have the same filename as the data)