### PR TITLE
add dtype selection and progess bar to bin_data_mmap

### DIFF
--- a/py4DSTEM/io/datastructure/datacube.py
+++ b/py4DSTEM/io/datastructure/datacube.py
@@ -97,7 +97,7 @@ class DataCube(DataObject):
         self = preprocess.bin_data_diffraction(self, bin_factor)
 
     def bin_data_mmap(self, bin_factor, dtype=np.float32):
-        self = preprocess.bin_data_mmap(self, bin_factor)
+        self = preprocess.bin_data_mmap(self, bin_factor, dtype=dtype)
 
     def bin_data_real(self, bin_factor):
         self = preprocess.bin_data_real(self, bin_factor)

--- a/py4DSTEM/io/datastructure/datacube.py
+++ b/py4DSTEM/io/datastructure/datacube.py
@@ -96,7 +96,7 @@ class DataCube(DataObject):
     def bin_data_diffraction(self, bin_factor):
         self = preprocess.bin_data_diffraction(self, bin_factor)
 
-    def bin_data_mmap(self, bin_factor):
+    def bin_data_mmap(self, bin_factor, dtype=np.float32):
         self = preprocess.bin_data_mmap(self, bin_factor)
 
     def bin_data_real(self, bin_factor):

--- a/py4DSTEM/process/preprocess/preprocess.py
+++ b/py4DSTEM/process/preprocess/preprocess.py
@@ -8,7 +8,7 @@
 #       datacube.preprocess_function(*args)
 
 import numpy as np
-from ..utils import bin2D
+from ..utils import bin2D, tqdmnd
 
 ### Editing datacube shape ###
 
@@ -111,19 +111,17 @@ def bin_data_diffraction(datacube, bin_factor):
         datacube.R_Nx,datacube.R_Ny,datacube.Q_Nx,datacube.Q_Ny = datacube.data.shape
         return datacube
 
-def bin_data_mmap(datacube, bin_factor):
+def bin_data_mmap(datacube, bin_factor, dtype=np.float32):
     """
     Performs diffraction space binning of data by bin_factor.
 
-    Note that this function casts data
     """
     assert type(bin_factor) is int, "Error: binning factor {} is not an int.".format(bin_factor)
     R_Nx,R_Ny,Q_Nx,Q_Ny = datacube.R_Nx,datacube.R_Ny,datacube.Q_Nx,datacube.Q_Ny
 
-    data = np.zeros((datacube.R_Nx,datacube.R_Ny,datacube.Q_Nx//bin_factor,datacube.Q_Ny//bin_factor),dtype=np.float64)
-    for Rx in range(datacube.R_Nx):
-        for Ry in range(datacube.R_Ny):
-            data[Rx,Ry,:,:] = bin2D(datacube.data[Rx,Ry,:,:],bin_factor,dtype=np.float64)
+    data = np.zeros((datacube.R_Nx,datacube.R_Ny,datacube.Q_Nx//bin_factor,datacube.Q_Ny//bin_factor),dtype=dtype)
+    for Rx, Ry in tqdmnd(datacube.R_Ny, datacube.R_Ny):
+        data[Rx,Ry,:,:] = bin2D(datacube.data[Rx,Ry,:,:],bin_factor,dtype=dtype)
 
     datacube.data = data
     datacube.R_Nx,datacube.R_Ny,datacube.Q_Nx,datacube.Q_Ny = datacube.data.shape

--- a/py4DSTEM/process/virtualimage/virtualimage.py
+++ b/py4DSTEM/process/virtualimage/virtualimage.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from ...io.datastructure import DataCube
+from ..utils import tqdmnd
 
 def test():
     return True
@@ -23,7 +24,9 @@ def get_virtualimage_rect(datacube, xmin, xmax, ymin, ymax):
     xmin,xmax = max(0,int(np.round(xmin))),min(datacube.Q_Nx,int(np.round(xmax)))
     ymin,ymax = max(0,int(np.round(ymin))),min(datacube.Q_Ny,int(np.round(ymax)))
 
-    virtual_image = np.sum(datacube.data[:,:,xmin:xmax,ymin:ymax], axis=(2,3))
+    virtual_image = np.zeros((datacube.R_Nx, datacube.R_Ny))
+    for rx,ry in tqdmnd(datacube.R_Nx,datacube.R_Ny):
+        virtual_image[rx,ry] = np.sum(datacube.data[rx,ry,xmin:xmax,ymin:ymax])
     return virtual_image
 
 def get_virtualimage_circ(datacube, x0, y0, R):
@@ -47,7 +50,9 @@ def get_virtualimage_circ(datacube, x0, y0, R):
     x0_s,y0_s = x0-xmin,y0-ymin
     mask = np.fromfunction(lambda x,y: ((x-x0_s+0.5)**2 + (y-y0_s+0.5)**2) < R**2, (xsize,ysize)) # Avoids making meshgrids
 
-    virtual_image = np.sum(datacube.data[:,:,xmin:xmax,ymin:ymax]*mask, axis=(2,3))
+    virtual_image = np.zeros((datacube.R_Nx, datacube.R_Ny))
+    for rx,ry in tqdmnd(datacube.R_Nx,datacube.R_Ny):
+        virtual_image[rx,ry] = np.sum(datacube.data[rx,ry,xmin:xmax,ymin:ymax]*mask)
     return virtual_image
 
 def get_virtualimage_ann(datacube, x0, y0, Ri, Ro):
@@ -74,7 +79,9 @@ def get_virtualimage_ann(datacube, x0, y0, Ri, Ro):
     mask_i = np.fromfunction(lambda x,y: ((x-x0_s+0.5)**2 + (y-y0_s+0.5)**2) < Ri**2, (xsize,ysize))
     mask = np.logical_xor(mask_o,mask_i)
 
-    virtual_image = np.sum(datacube.data[:,:,xmin:xmax,ymin:ymax]*mask, axis=(2,3))
+    virtual_image = np.zeros((datacube.R_Nx, datacube.R_Ny))
+    for rx,ry in tqdmnd(datacube.R_Nx,datacube.R_Ny):
+        virtual_image[rx,ry] = np.sum(datacube.data[rx,ry,xmin:xmax,ymin:ymax]*mask)
     return virtual_image
 
 


### PR DESCRIPTION
A tiny tweak to allow choice of the target dtype when binning a memory mapped DataCube. Changes the for loop to use `tqdmnd` for progress updates. 