### PR TITLE
more GUI fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ You can do this in the command line with `conda activate py4dstem`, or, if you'r
 
 ## Running the GUI
 
-**WARNING: the GUI is currently down. Thanks for you patience as we work through various bugs!**
-
 At this stage of development, most of the analyses possible with py4DSTEM are accomplished using the code in .py scripts or .ipynb jupyter notebooks -- discussed further immediately below.
 Our intention is to support many of these analyses through the GUI eventually.
 At present the primary utility of the GUI is for browsing and visualizing 4DSTEM data.
@@ -76,7 +74,11 @@ conda activate py4dstem
 py4dstem
 ```
 
-
+A filename can be passed as a command line argument to the GUI to open that file immediately:
+```
+conda activate py4dstem
+py4dstem path/to/data/file.h5
+```
 
 ## Running the code
 

--- a/py4DSTEM/gui/gui_utils.py
+++ b/py4DSTEM/gui/gui_utils.py
@@ -52,7 +52,7 @@ def datacube_selector(fp, data_id=0):
             indices.appen(info[i]['index'])
             return names,indices
     if N_dc == 1:
-        i = inds[0]
+        i = int(inds[0])
         dc = read_py4DSTEM(fp, data_id=i)
         return dc
     elif N_dc > 1:

--- a/py4DSTEM/gui/gui_utils.py
+++ b/py4DSTEM/gui/gui_utils.py
@@ -41,6 +41,7 @@ def datacube_selector(fp, data_id=0):
     else:
         raise Exception("This EMD file version is not supported by the GUI.")
 
+    print(f"Reading py4DSTEM EMD version {version_major}.{version_minor}.{version_release}")
     info = get_py4DSTEM_dataobject_info(fp,topgroup)
     inds = nonzero(info['type']=='DataCube')[0]
     N_dc = len(inds)

--- a/py4DSTEM/gui/viewer.py
+++ b/py4DSTEM/gui/viewer.py
@@ -90,6 +90,8 @@ class DataViewer(QtWidgets.QMainWindow):
         self.diffraction_space_widget.normRadioChanged()
 
         if len(argv) > 1:
+            from PyQt5.QtWidgets import QApplication
+            QApplication.processEvents()
             path = os.path.abspath(argv[1])
             try:
                 self.settings.data_filename.val = path

--- a/py4DSTEM/io/native/read/read_v0_5.py
+++ b/py4DSTEM/io/native/read/read_v0_5.py
@@ -114,7 +114,7 @@ def print_py4DSTEM_file(fp,tg):
     """
     info = get_py4DSTEM_dataobject_info(fp,tg)
 
-    version = get_py4DSTEM_version(filepath, tg)
+    version = get_py4DSTEM_version(fp, tg)
     print(f"py4DSTEM file version {version[0]}.{version[1]}.{version[2]}")
 
     print("{:10}{:18}{:24}{:54}".format('Index', 'Type', 'Shape', 'Name'))
@@ -250,9 +250,9 @@ def get_datacube_from_grp(g,mem='RAM',binfactor=1,bindtype=None):
     assert binfactor == 1, "Bin on load is currently unsupported for EMD files."
 
     if (mem, binfactor) == ("RAM", 1):
-        data = np.array(g['data'])
+        data = np.array(g['datacube'])
     elif (mem, binfactor) == ("MEMMAP", 1):
-        data = g['data']
+        data = g['datacube']
     
     name = g.name.split('/')[-1]
     return DataCube(data=data,name=name)


### PR DESCRIPTION
This PR fixes bugs that affected reading EMD files in the GUI that remained after PR #179 . 

I have tested this on py4DSTEM EMD file versions 0.12, 0.9, 0.6, and 0.5, and it loads them correctly. I have deliberately only edited things in the GUI code to keep any potential new bugs contained, though a cleaner solution integrated into the rest of the reader functions is probably warranted in the future. 