### PR TITLE
Remove "index_mask" from bragg intensity map function

### DIFF
--- a/py4DSTEM/process/latticevectors/index.py
+++ b/py4DSTEM/process/latticevectors/index.py
@@ -252,8 +252,6 @@ def bragg_vector_intensity_map_by_index(braggpeaks,h,k, symmetric=False):
                 else:
                     matches = np.logical_and(pl.data['h'] == h, pl.data['k'] == k)
 
-                # now apply the indexing mask
-                matches = np.logical_and(matches, pl.data['index_mask'])
                 if len(matches)>0:
                     intensity_map[Rx,Ry] = np.sum(pl.data['intensity'][matches])
 


### PR DESCRIPTION
The `bragg_vector_intensity_map_by_index` function had a bug (pointed out in #150) where it looked for a coordinate in the `PointList` that we have since removed. That coordinate, `index_mask`, was used to indicate which Bragg peaks were successfully assigned an index (i.e. those that fell within `maxPeakSpacing` of a `braggdirection`, when performed using `add_indices_to_braggpeaks`). At some point, the behavior of `add_indices_to_braggpeaks` was changed so that rather than including _all_ the Bragg peaks and noting which were correctly indexed, the un-indexable Bragg peaks were simply dropped. 

`bragg_vector_intensity_map_by_index` was not updated to reflect this change, and so looked for the `index_mask` coordinate, causing it to error. Because of the new behavior of `add_indices_to_braggpeaks`, the purpose served by `index_mask` is now handled for us already and we can simply drop this line. 

(This PR should probably be all of the code changes that #150 needs but there are other questions in that issue that may need more attention.)