### PR TITLE
Fix EMD v0.12 DataCube MEMMAP

### DIFF
--- a/py4DSTEM/io/datastructure/datacube.py
+++ b/py4DSTEM/io/datastructure/datacube.py
@@ -10,8 +10,6 @@ import numpy as np
 import numba as nb
 import h5py
 
-from ncempy.io import emd
-
 from .dataobject import DataObject
 from ...process import preprocess
 from ...process import virtualimage_viewer as virtualimage
@@ -293,8 +291,7 @@ def get_datacube_from_grp(g,mem='RAM',binfactor=1,bindtype=None):
     if (mem, binfactor) == ("RAM", 1):
         data = np.array(g['data'])
     elif (mem, binfactor) == ("MEMMAP", 1):
-        emdF = emd.fileEMD(g.file.filename)
-        data, dims = emdF.get_memmap(0)
+        data = g['data']
     name = g.name.split('/')[-1]
     return DataCube(data=data,name=name)
 


### PR DESCRIPTION
As was noted in the discussion of PR #174, using `ncempy.io.emd.fileEMD` does not work for memory mapping, as the handle to the HDF5 file gets explicitly closed when the `fileEMD` object gets garbage collected. As a result, py4DSTEM files made with v0.12 could not be memory mapped (older version files are handled in several mostly redundant functions scattered throughout the reader files, and instead used the method from PR #182 which does not have the same problem). 

This PR simply replaces the two lines in the DataCube version of `get_datacube_from_grp` to use the memmap-compatible approach. 