### PR TITLE
Fix for reading `PointListArray`s and `PointList`s from EMD files

### DIFF
--- a/py4DSTEM/io/datastructure/pointlist.py
+++ b/py4DSTEM/io/datastructure/pointlist.py
@@ -38,7 +38,7 @@ class PointList(DataObject):
         self.length = 0  #: the number of coordinates
 
         # Define the data type for the PointList structured array
-        if type(coordinates) in (type, np.dtype):
+        if isinstance(coordinates,np.dtype):
             self.dtype = coordinates  #: the custom datatype, generated from the coordinates
         elif type(coordinates[0])==str:
             self.dtype = np.dtype([(name,self.default_dtype) for name in coordinates])

--- a/py4DSTEM/io/datastructure/pointlistarray.py
+++ b/py4DSTEM/io/datastructure/pointlistarray.py
@@ -34,7 +34,7 @@ class PointListArray(DataObject):
         self.shape = shape
 
         # Define the data type for the structured arrays in the PointLists
-        if type(coordinates) in (type, np.dtype):
+        if isinstance(coordinates, np.dtype):
             self.dtype = coordinates  # the custom datatype; see the PointList documentation
         elif type(coordinates[0])==str:
             self.dtype = np.dtype([(name,self.default_dtype) for name in coordinates])


### PR DESCRIPTION
When creating `PointListArray`s and `PointList`s, we were previously using this line to check if the user-supplied datatype is already a numpy dtype object:
```python
if type(coordinates) in (type, np.dtype):
```
However, this fails under various and erratic circumstances. Numpy can create subclasses of `np.dtype` dynamically so testing equality of the types is not guaranteed to work. You could devise some more complex tests for this case (I indeed tried) but those are ugly, since `is` is just not the appropriate comparator here. So it seems the best way to perform this test is actually:
```python
if isinstance(coordinates, np.dtype):
```
which handles the subclassing just fine. 