### PR TITLE
Some more small tweaks

### DIFF
--- a/py4DSTEM/gui/viewer.py
+++ b/py4DSTEM/gui/viewer.py
@@ -808,7 +808,7 @@ class DataViewer(QtWidgets.QMainWindow):
             new_real_space_view, success = self.get_virtual_image(slice_x,slice_y)
             if success:
                 self.real_space_view = new_real_space_view
-                self.real_space_widget.setImage(self.real_space_view,autoLevels=True)
+                self.real_space_widget.setImage(self.real_space_view.T,autoLevels=True)
             else:
                 pass
 
@@ -825,7 +825,7 @@ class DataViewer(QtWidgets.QMainWindow):
             new_real_space_view, success = self.get_virtual_image(slice_x,slice_y,R)
             if success:
                 self.real_space_view = new_real_space_view
-                self.real_space_widget.setImage(self.real_space_view,autoLevels=True)
+                self.real_space_widget.setImage(self.real_space_view.T,autoLevels=True)
             else:
                 pass
 

--- a/py4DSTEM/gui/viewer.py
+++ b/py4DSTEM/gui/viewer.py
@@ -771,7 +771,7 @@ class DataViewer(QtWidgets.QMainWindow):
                 self.diffraction_space_view = np.abs(np.fft.fftshift(np.fft.fft2(np.log(
                     (h*(self.diffraction_space_view - np.min(self.diffraction_space_view))) + 1))))**2
 
-            self.diffraction_space_widget.setImage(self.diffraction_space_view,
+            self.diffraction_space_widget.setImage(self.diffraction_space_view.T,
                                                    autoLevels=False,autoRange=False)
         else:
             pass
@@ -784,7 +784,7 @@ class DataViewer(QtWidgets.QMainWindow):
         if detector_shape == 0:
             # Get slices corresponding to ROI
             slices, transforms = self.virtual_detector_roi.getArraySlice(self.datacube.data[0,0,:,:], self.diffraction_space_widget.getImageItem())
-            slice_x,slice_y = slices
+            slice_y, slice_x = slices
 
             # Get the virtual image and set the real space view
             new_real_space_view, success = self.get_virtual_image(slice_x,slice_y)
@@ -802,7 +802,7 @@ class DataViewer(QtWidgets.QMainWindow):
         elif detector_shape == 1:
             # Get slices corresponding to ROI
             slices, transforms = self.virtual_detector_roi.getArraySlice(self.datacube.data[0,0,:,:], self.diffraction_space_widget.getImageItem())
-            slice_x,slice_y = slices
+            slice_y, slice_x = slices
 
             # Get the virtual image and set the real space view
             new_real_space_view, success = self.get_virtual_image(slice_x,slice_y)
@@ -816,7 +816,7 @@ class DataViewer(QtWidgets.QMainWindow):
         elif detector_shape == 2:
             # Get slices corresponding to ROI
             slices, transforms = self.virtual_detector_roi_outer.getArraySlice(self.datacube.data[0,0,:,:], self.diffraction_space_widget.getImageItem())
-            slice_x,slice_y = slices
+            slice_y, slice_x = slices
             slices_inner, transforms = self.virtual_detector_roi_inner.getArraySlice(self.datacube.data[0,0,:,:], self.diffraction_space_widget.getImageItem())
             slice_inner_x,slice_inner_y = slices_inner
             R = 0.5*((slice_inner_x.stop-slice_inner_x.start)/(slice_x.stop-slice_x.start) + (slice_inner_y.stop-slice_inner_y.start)/(slice_y.stop-slice_y.start))

--- a/py4DSTEM/gui/viewer.py
+++ b/py4DSTEM/gui/viewer.py
@@ -748,7 +748,7 @@ class DataViewer(QtWidgets.QMainWindow):
 
     def update_diffraction_space_view(self):
         roi_state = self.real_space_point_selector.saveState()
-        x0,y0 = roi_state['pos']
+        y0,x0 = roi_state['pos']
         xc,yc = int(x0+1),int(y0+1)
 
         # Set the diffraction space image
@@ -790,7 +790,7 @@ class DataViewer(QtWidgets.QMainWindow):
             new_real_space_view, success = self.get_virtual_image(slice_x,slice_y)
             if success:
                 self.real_space_view = new_real_space_view
-                self.real_space_widget.setImage(self.real_space_view,autoLevels=True)
+                self.real_space_widget.setImage(self.real_space_view.T,autoLevels=True)
 
                 #update the label:
                 self.diffraction_space_view_text.setText(

--- a/py4DSTEM/process/calibration/origin.py
+++ b/py4DSTEM/process/calibration/origin.py
@@ -4,9 +4,9 @@ import numpy as np
 from scipy.ndimage.filters import gaussian_filter
 from scipy.optimize import leastsq
 
-from ..fit import plane,parabola,bezier_two,fit_2D
-from ..utils import get_CoM, add_to_2D_array_from_floats,tqdmnd
-from ...io.datastructure import PointListArray
+from ..fit import plane, parabola, bezier_two, fit_2D
+from ..utils import get_CoM, add_to_2D_array_from_floats, tqdmnd
+from ...io import PointListArray, DataCube
 from ..diskdetection.braggvectormap import get_bragg_vector_map
 
 


### PR DESCRIPTION
This PR does two things:
- Solves the problem in origin.py where testing `isinstance(pla,PointListArray)` would fail even though `pla` was a `PointListArray`. @PhilippPelz pointed us to [this stackoverflow](https://stackoverflow.com/questions/21498211/using-isinstance-in-modules) that explains the problem: importing from `...io.datastructure` would re-import that file, creating a new instance of the `PointListArray` class that is different from the one you call when creating a `PointListArray` through the module. Thus the classes were not the same object, and the `isinstance` test would return `False`. By changing the import to `...io`, we get the same object as the rest of the module, and the problem is solved (at least in this file... similar issues may lurk elsewhere). 
- Transposes the images shown in the GUI so that they match how it would appear in matplotlib or in Digital Micrograph. When using the GUI at the Titan, it is often rather confusing that the image is transposed from how it appeared to the operator.