### PR TITLE
Automatic zone axis range determination from point group symmetry

### DIFF
--- a/py4DSTEM/process/diffraction/crystal.py
+++ b/py4DSTEM/process/diffraction/crystal.py
@@ -693,7 +693,7 @@ class Crystal:
             assert pointgroup in orientation_ranges, "Unrecognized pointgroup returned by pymatgen!"
 
             zone_axis_range, fiber_axis, fiber_angles = orientation_ranges[pointgroup]
-            zone_axis_range = np.array(zone_axis_range)
+            zone_axis_range = np.array(zone_axis_range, dtype=np.float64)
             self.cartesian_directions = True # the entries in the orientation_ranges object assume cartesian zones
 
             print(f"Automatically detected point group {pointgroup}, using arguments: zone_axis_range={zone_axis_range}, fiber_axis={fiber_axis}, fiber_angles={fiber_angles}.")


### PR DESCRIPTION
This adds the option `zone_axis_range='auto'` to `orientation_plan`. Using pymatgen we determine the point group of the crystal, then choose from a list of predefined sets of arguments for specifying the zone axes, which match the symmetry of the crystal. 

I have tested that at least for fcc Au and orthorhombic rubrene this returns the right result. 

I am not sure about the options for point group 23, I think it may not be possible to specify its symmetric wedge exactly using our methods. The others all seem to translate OK. I made these input choices based on inspection of the stereographic projections in Appendix A4 of De Graef.

The next step here is to also use these symmetries in coloring the orientation plots...