### PR TITLE
make scaling for radius and intensity user-selectable

### DIFF
--- a/py4DSTEM/process/diffraction/crystal.py
+++ b/py4DSTEM/process/diffraction/crystal.py
@@ -662,8 +662,8 @@ class Crystal:
             angle_step_in_plane (float):  Approximate angular step size for in-plane rotation [degrees]
             accel_voltage (float):        Accelerating voltage for electrons [Volts]
             corr_kernel_size (float):        Correlation kernel size length in Angstroms
-            radial_power (float):          Power for scaling the correlation intensity of each radial bin
-            intensity_power (float):       Power for scaling the intensity of structure factors
+            radial_power (float):          Power for scaling the correlation intensity as a function of the peak radius
+            intensity_power (float):       Power for scaling the correlation intensity as a function of the peak intensity
             tol_peak_delete (float):      Distance to delete peaks for multiple matches.
                                           Default is kernel_size * 0.5
             tol_distance (float):         Distance tolerance for radial shell assignment [1/Angstroms]
@@ -689,8 +689,8 @@ class Crystal:
         self.wavelength = electron_wavelength_angstrom(self.accel_voltage)
 
         # store the radial and intensity scaling to use later for generating test patterns
-        self.radial_power = radial_power
-        self.intensity_power = intensity_power
+        self.orientation_radial_power = radial_power
+        self.orientation_intensity_power = intensity_power
 
         # Handle the "auto" case first, since it works by overriding zone_axis_range,
         #   fiber_axis, and fiber_angles then using the regular parser:
@@ -1779,8 +1779,8 @@ class Crystal:
 
                 if np.sum(sub) > 0:
                     im_polar[ind_radial, :] = np.sum(
-                        np.power(radius,self.radial_power)
-                        * np.power(np.max(intensity[sub, None],0),self.intensity_power)
+                        np.power(radius,self.orientation_radial_power)
+                        * np.power(np.max(intensity[sub, None],0),self.orientation_intensity_power)
                         * np.maximum(
                             1
                             - np.sqrt(


### PR DESCRIPTION
This small tweak implements the suggestion that has been floating around about making the scaling powers of both the shell radius and the peak intensity user-selectable. They can be specified at the creation of the orientation plan, and are saved for later use when scaling the correlation images in the pattern matching. 