### PR TITLE
addressing flake8 fatal errors

### DIFF
--- a/py4DSTEM/gui/gui_utils.py
+++ b/py4DSTEM/gui/gui_utils.py
@@ -12,7 +12,7 @@ collectively contained in an LQCollection object. The key advantages of LoggedQu
 from os.path import join, dirname, expanduser
 from PyQt5 import QtCore, QtWidgets
 from numpy import nonzero
-from ..io.native import read_py4DSTEM, get_py4DSTEM_topgroups, get_py4DSTEM_version
+from ..io.native import read_py4DSTEM, get_py4DSTEM_topgroups, get_py4DSTEM_version, get_N_dataobjects
 import pyqtgraph as pg
 
 def datacube_selector(fp, data_id=0):
@@ -62,31 +62,6 @@ def datacube_selector(fp, data_id=0):
         return dc
     else:
         print("No datacubes found in this file.")
-
-
-def datacube_selector_dialog(fpath,window):
-    """
-    Presents the user with a dialog to choose one of the datacubes inside the file,
-    if more than one exists. Returns the selected DataCube object.
-    """
-    info = get_py4DSTEM_dataobject_info(fpath)
-    inds = np.nonzero(info['type']=='DataCube')[0]
-    N_dc = len(inds)
-
-    if N_dc == 1:
-        ind = inds[0]
-        dc = read_py4DSTEM(fpath, data_id=ind)
-    elif N_dc > 1:
-        # there is more than one object, so we need to present the user with a chooser
-        #indices = (self.dataobject_lookup_arr=='DataCube' | 
-        #    self.dataobject_lookup_arr=='RawDataCube').nonzero()[0]
-        print('More than one datacube detected...')
-        print('Pls harass developers to add support feature.')
-
-    return dc
-
-
-
 
 def sibling_path(fpath, fname):
     """
@@ -220,7 +195,7 @@ class LoggedQuantity(QtCore.QObject):
                 self.update_value(widget.text())
             widget.editingFinished.connect(on_edit_finished)
 
-        elif type(widget) == QtWidget.QLabel:
+        elif type(widget) == QtWidgets.QLabel:
             self.updated_value.connect(widget.setText)
 
         elif type(widget) == pg.widgets.SpinBox.SpinBox:

--- a/py4DSTEM/io/native/metadata/h5rw.py
+++ b/py4DSTEM/io/native/metadata/h5rw.py
@@ -201,7 +201,8 @@ def _h5write(filename, mode, grouppath, *args, **kwargs):
             if h5options['UNSUPPORTED'] == 'fail':
                 raise RuntimeError('Unsupported data type : %s' % type(a))
             elif h5options['UNSUPPORTED'] == 'pickle':
-                dset = _store_pickle(group, a, name)
+                # dset = _store_pickle(group, a, name)
+                raise NotImplementedError("Pickling is not supported.")
             else:
                 dset = None
         return dset

--- a/py4DSTEM/io/native/metadata/metadata_rw.py
+++ b/py4DSTEM/io/native/metadata/metadata_rw.py
@@ -2,7 +2,7 @@ import h5py
 from os.path import exists
 from ...datastructure import Metadata
 from .h5rw import h5write,h5read,h5append,h5info
-from ..read import is_py4DSTEM_file,get_py4DSTEM_topgroups
+from ..read.read_utils import is_py4DSTEM_file,get_py4DSTEM_topgroups
 
 def metadata_to_h5(fp, metadata, overwrite=False, topgroup='4DSTEM_experiment'):
     """

--- a/py4DSTEM/io/native/read/read_v0_12.py
+++ b/py4DSTEM/io/native/read/read_v0_12.py
@@ -13,6 +13,7 @@ from ...datastructure import PointList, get_pointlist_from_grp
 from ...datastructure import PointListArray, get_pointlistarray_from_grp
 from ...datastructure import Coordinates, get_coordinates_from_grp
 from ....process.utils import tqdmnd
+from ..metadata import metadata_from_h5
 
 def read_v0_12(fp, **kwargs):
     """

--- a/py4DSTEM/io/native/read/read_v0_5.py
+++ b/py4DSTEM/io/native/read/read_v0_5.py
@@ -159,7 +159,7 @@ def get_data_from_int(fp,tg,data_id,mem='RAM',binfactor=1,bindtype=None):
             data = get_data_from_grp(grp_data,mem=mem,binfactor=binfactor,bindtype=bindtype)
 
     if mem == "MEMMAP":
-        f = h5py.File(filepath,'r')
+        f = h5py.File(fp,'r')
         grp_data = f[group_name]
         data = get_data_from_grp(grp_data,mem=mem,binfactor=binfactor,bindtype=bindtype)
 
@@ -202,7 +202,7 @@ def get_data_from_str(fp,tg,data_id,mem='RAM',binfactor=1,bindtype=None):
     # if using MEMMAP, file cannot be accessed from the context manager
     # or else it will be closed before the data is accessed
     if mem == "MEMMAP":
-        f = h5py.File(filepath,'r')
+        f = h5py.File(fp,'r')
         grp_data = f[group_name]
         data = get_data_from_grp(grp_data,mem=mem,binfactor=binfactor,bindtype=bindtype)
 

--- a/py4DSTEM/io/native/read/read_v0_6.py
+++ b/py4DSTEM/io/native/read/read_v0_6.py
@@ -114,7 +114,7 @@ def print_py4DSTEM_file(fp,tg):
     """
     info = get_py4DSTEM_dataobject_info(fp,tg)
 
-    version = get_py4DSTEM_version(filepath, tg)
+    version = get_py4DSTEM_version(fp, tg)
     print(f"py4DSTEM file version {version[0]}.{version[1]}.{version[2]}")
 
     print("{:10}{:18}{:24}{:54}".format('Index', 'Type', 'Shape', 'Name'))
@@ -159,7 +159,7 @@ def get_data_from_int(fp,tg,data_id,mem='RAM',binfactor=1,bindtype=None):
             data = get_data_from_grp(grp_data,mem=mem,binfactor=binfactor,bindtype=bindtype)
 
     if mem == "MEMMAP":
-        f = h5py.File(filepath,'r')
+        f = h5py.File(fp,'r')
         grp_data = f[group_name]
         data = get_data_from_grp(grp_data,mem=mem,binfactor=binfactor,bindtype=bindtype)
 
@@ -202,7 +202,7 @@ def get_data_from_str(fp,tg,data_id,mem='RAM',binfactor=1,bindtype=None):
     # if using MEMMAP, file cannot be accessed from the context manager
     # or else it will be closed before the data is accessed
     if mem == "MEMMAP":
-        f = h5py.File(filepath,'r')
+        f = h5py.File(fp,'r')
         grp_data = f[group_name]
         data = get_data_from_grp(grp_data,mem=mem,binfactor=binfactor,bindtype=bindtype)
 

--- a/py4DSTEM/io/native/read/read_v0_7.py
+++ b/py4DSTEM/io/native/read/read_v0_7.py
@@ -114,7 +114,7 @@ def print_py4DSTEM_file(fp,tg):
     """
     info = get_py4DSTEM_dataobject_info(fp,tg)
 
-    version = get_py4DSTEM_version(filepath, tg)
+    version = get_py4DSTEM_version(fp, tg)
     print(f"py4DSTEM file version {version[0]}.{version[1]}.{version[2]}")
 
     print("{:10}{:18}{:24}{:54}".format('Index', 'Type', 'Shape', 'Name'))
@@ -159,7 +159,7 @@ def get_data_from_int(fp,tg,data_id,mem='RAM',binfactor=1,bindtype=None):
             data = get_data_from_grp(grp_data,mem=mem,binfactor=binfactor,bindtype=bindtype)
 
     if mem == "MEMMAP":
-        f = h5py.File(filepath,'r')
+        f = h5py.File(fp,'r')
         grp_data = f[group_name]
         data = get_data_from_grp(grp_data,mem=mem,binfactor=binfactor,bindtype=bindtype)
 
@@ -202,7 +202,7 @@ def get_data_from_str(fp,tg,data_id,mem='RAM',binfactor=1,bindtype=None):
     # if using MEMMAP, file cannot be accessed from the context manager
     # or else it will be closed before the data is accessed
     if mem == "MEMMAP":
-        f = h5py.File(filepath,'r')
+        f = h5py.File(fp,'r')
         grp_data = f[group_name]
         data = get_data_from_grp(grp_data,mem=mem,binfactor=binfactor,bindtype=bindtype)
 

--- a/py4DSTEM/io/native/read/read_v0_9.py
+++ b/py4DSTEM/io/native/read/read_v0_9.py
@@ -8,6 +8,7 @@ from .read_utils_v0_9 import get_py4DSTEM_dataobject_info
 from ...datastructure import DataCube, CountedDataCube, DiffractionSlice, RealSlice
 from ...datastructure import PointList, PointListArray
 from ....process.utils import tqdmnd
+from ..metadata import metadata_from_h5
 
 def read_v0_9(fp, **kwargs):
     """

--- a/py4DSTEM/io/native/write/copy.py
+++ b/py4DSTEM/io/native/write/copy.py
@@ -30,7 +30,7 @@ def copy(filepath_orig, filepath_new, indices=None, delete=False,
     """
     assert(is_py4DSTEM_file(filepath_orig)), "Error: not recognized as a py4DSTEM file."
     tgs = get_py4DSTEM_topgroups(filepath_orig)
-    assert(topgroup_orig in tgs), "Error: topgroup '{}' not found.".format(topgroup)
+    assert(topgroup_orig in tgs), "Error: topgroup '{}' not found.".format(topgroup_orig)
     if exists(filepath_new):
         assert(is_py4DSTEM_file(filepath_new)), "Error: a file with the target filename already exists, and is not recognized as a py4DSTEM file."
         tgs = get_py4DSTEM_topgroups(filepath_new)

--- a/py4DSTEM/process/calibration/ellipse.py
+++ b/py4DSTEM/process/calibration/ellipse.py
@@ -47,6 +47,7 @@ where b = a*e is the semiminor axis length.
 """
 
 import numpy as np
+import matplotlib.pyplot as plt
 from scipy.optimize import leastsq, least_squares
 from scipy.ndimage.filters import gaussian_filter
 from scipy.signal import savgol_filter

--- a/py4DSTEM/process/diskdetection/diskdetection.py
+++ b/py4DSTEM/process/diskdetection/diskdetection.py
@@ -629,7 +629,7 @@ def find_Bragg_disks(datacube, probe,
 
 
 def threshold_Braggpeaks(pointlistarray, minRelativeIntensity, relativeToPeak,
-                         minPeakSpcing, maxNumPeaks):
+                         minPeakSpacing, maxNumPeaks):
     """
     Takes a PointListArray of detected Bragg peaks and applies additional thresholding,
     returning the thresholded PointListArray. To skip a threshold, set that parameter to

--- a/py4DSTEM/process/dpc/dpc.py
+++ b/py4DSTEM/process/dpc/dpc.py
@@ -393,7 +393,7 @@ def construct_illumation(shape, size, keV, aperture, ap_in_mrad=True,
 
     # Get diffraction space coordinates
     qsize = (float(Nx)/xsize,float(Ny)/ysize)
-    qx,qy = make_qspace_coords(shape, qsize)
+    qx, qy = np.meshgrid(np.fft.fftfreq(Nx, qsize[0]), np.fft.fftfreq(Ny, qsize[1]))
     qr = np.sqrt(qx**2 + qy**2)
 
     # Get electron wavenumber and aperture size

--- a/py4DSTEM/process/dpc/dpc.py
+++ b/py4DSTEM/process/dpc/dpc.py
@@ -393,7 +393,7 @@ def construct_illumation(shape, size, keV, aperture, ap_in_mrad=True,
 
     # Get diffraction space coordinates
     qsize = (float(Nx)/xsize,float(Ny)/ysize)
-    qx, qy = np.meshgrid(np.fft.fftfreq(Nx, qsize[0]), np.fft.fftfreq(Ny, qsize[1]))
+    qx, qy = make_Fourier_coords2D(qsize[0],qsize[1])
     qr = np.sqrt(qx**2 + qy**2)
 
     # Get electron wavenumber and aperture size
@@ -490,26 +490,7 @@ def get_interaction_constant(E):
 
 ####################### Utility functions ##########################
 
-# def make_qspace_coords(shape,qsize):
-#     """
-#     Creates a diffraction space coordinate grid.
-# 
-#     Number of pixels in the grid (sampling) is given by shape = (Nx,Ny).
-#     Extent of the grid is given by qsize = (xsize,ysize), where xsize,ysize are in inverse length
-#     units, and are the number of pixels divided by the real space size.
-# 
-#     Accepts:
-#         shape       (2-tuple of ints) grid shape
-#         qsize       (2-tuple of floats) grid size, in reciprocal length units
-# 
-#     Returns:
-#         qx          (2D ndarray) the x diffraction space coordinates
-#         qy          (2D ndarray) the y diffraction space coordinates
-#     """
-#     qx = np.fft.fftfreq(shape[0])*qsize[0]
-#     qy = np.fft.fftfreq(shape[1])*qsize[1]
-#     return qx,qy
-# 
+
 # def pad_shift(ar, x, y):
 #     """
 #     Similar to np.roll, but designed for special handling of zero padded matrices.

--- a/py4DSTEM/process/preprocess/electroncount.py
+++ b/py4DSTEM/process/preprocess/electroncount.py
@@ -193,7 +193,7 @@ def electron_count_GPU(datacube, darkreference, Nsamples=40,
             else:
                 # I'm not sure I understand this - we're flipping coordinates to match what?
                 # TODO: check array flipping - may vary by camera
-                counted[Rx,Ry,:,:]=torch.transpose(events.type(torch_.cuda.ShortTensor),0,1).flip(0).flip(1)
+                counted[Rx,Ry,:,:]=torch.transpose(events.type(torch.cuda.ShortTensor),0,1).flip(0).flip(1)
 
     if output=='datacube':
         return counted.cpu().numpy()
@@ -303,6 +303,9 @@ def torch_bin(array,device,factor=2):
     Returns:
         (array): the binned array
     """
+
+    import torch
+
     x,y =  array.shape
     binx,biny = x//factor,y//factor
     xx,yy = binx*factor,biny*factor
@@ -376,6 +379,8 @@ def counted_pointlistarray_to_datacube(counted_pointlistarray, shape, subpixel=F
 if __name__=="__main__":
 
     from py4DSTEM.process.preprocess import get_darkreference
+    from py4DSTEM.io import DataCube, save
+    from ncempy.io import dm
 
     dm4_filepath = 'Capture25.dm4'
 
@@ -392,7 +397,7 @@ if __name__=="__main__":
 
 
     # Get memory mapped 4D datacube from dm file
-    datacube = dm.dmReader(dm4filename,dSetNum=0,verbose=False)['data']
+    datacube = dm.dmReader(dm4_filepath,dSetNum=0,verbose=False)['data']
     datacube = np.moveaxis(datacube,(0,1),(2,3))
 
     # Get dark reference
@@ -407,9 +412,9 @@ if __name__=="__main__":
 
     # For outputting datacubes, wrap counted into a py4DSTEM DataCube
     if output=='datacube':
-        electron_counted_data = DataCube(data=counted)
+        electron_counted_data = DataCube(data=electron_counted_data)
 
-    output_path = dm4filename.replace('.dm4','.h5')
+    output_path = dm4_filepath.replace('.dm4','.h5')
     save(electron_counted_data, output_path)
 
 

--- a/py4DSTEM/process/preprocess/relativity.py
+++ b/py4DSTEM/process/preprocess/relativity.py
@@ -168,13 +168,9 @@ def slice_mrc_stack(mrc, scratch, scanshape, optx, opty, startframe=0, wx=500, w
 
 	vstack = np.memmap(scratch, mode='w+', dtype='<i2', shape=dshape)
 
-	f = FloatProgress(min=0,max=nframe-1)
-	display(f)
-
 	t0 = time()
 
 	for i in np.arange(startframe,startframe+nframe):
-		f.value = i-startframe
 		frame = mrc.data[int(i),:,:]
 		stack = slice_subframes(frame,optx,opty,wx,wy)
 		vstack[int(i-startframe),:,:,:] = np.transpose(stack,(2,0,1))

--- a/py4DSTEM/visualize/show.py
+++ b/py4DSTEM/visualize/show.py
@@ -1,4 +1,4 @@
-from .overlay import add_rectangles,add_circles,add_annuli,add_ellipses,add_points
+from .overlay import add_rectangles,add_circles,add_annuli,add_ellipses,add_points, add_grid_overlay
 from .overlay import add_cartesian_grid,add_polarelliptical_grid,add_rtheta_grid,add_scalebar
 from ..io.datastructure import Coordinates
 
@@ -351,7 +351,7 @@ def show(ar,figsize=(8,8),cmap='gray',scaling='none',clipvals='minmax',
     if points is not None:
         add_points(ax,points)
     if grid_overlay is not None:
-        add_grid_overly(ax,grid)
+        add_grid_overlay(ax,grid_overlay)
 
 
     # Parse arguments for scale/coordinate overlays
@@ -466,7 +466,7 @@ def show(ar,figsize=(8,8),cmap='gray',scaling='none',clipvals='minmax',
 
     # Add r-theta grid
     if rtheta_grid is not None:
-        add_rtheta_grid(ax,grid)
+        add_rtheta_grid(ax,rtheta_grid)
 
     # Show or return
     returnval = []
@@ -524,7 +524,7 @@ def show_hist(arr, bins=200, vlines=None, vlinecolor='k', vlinestyle='--',
         plt.show()
         return
     elif returnhist and not returnfig:
-        return counts,bins_edges
+        return counts,bin_edges
     elif not returnhist and returnfig:
         return fig, ax
     else:

--- a/py4DSTEM/visualize/vis_special.py
+++ b/py4DSTEM/visualize/vis_special.py
@@ -513,7 +513,7 @@ def select_lattice_vectors(ar,gx,gy,i0,i1,i2,
     add_vector(ax2,dg2)
 
     if returnfig:
-        return g1,g2,fig,ax
+        return g1,g2,fig,(ax1,ax2)
     else:
         plt.show()
         return g1,g2


### PR DESCRIPTION
Just panning around the repo in Sublime, there are quite a few fatal errors that are hiding in rarely-visited places that the linter can nevertheless detect. So I took a little time to find and address as many of these problems as I could to clean up the codebase a tad.

To find the errors addressed here, I ran the following command:
```flake8 --select=F402,F404,F812,F823,F831,F821,F822,E112,E113,E901,E902,E999 py4DSTEM```
where the selected errors are those that SublimeLinter considers "errors" rather than "warnings", and indicate code that *will* throw an error if attempted to run. 

At the start, we encounter the following fatal errors:
```
$ flake8 --select=F402,F404,F812,F823,F831,F821,F822,E112,E113,E901,E902,E999 py4DSTEM
py4DSTEM/io/native/write/copy.py:33:76: F821 undefined name 'topgroup'
py4DSTEM/io/native/read/read_v0_5.py:162:23: F821 undefined name 'filepath'
py4DSTEM/io/native/read/read_v0_5.py:205:23: F821 undefined name 'filepath'
py4DSTEM/io/native/read/read_v0_9.py:80:20: F821 undefined name 'metadata_from_h5'
py4DSTEM/io/native/read/read_v0_7.py:117:36: F821 undefined name 'filepath'
py4DSTEM/io/native/read/read_v0_7.py:162:23: F821 undefined name 'filepath'
py4DSTEM/io/native/read/read_v0_7.py:205:23: F821 undefined name 'filepath'
py4DSTEM/io/native/read/read_v0_6.py:117:36: F821 undefined name 'filepath'
py4DSTEM/io/native/read/read_v0_6.py:162:23: F821 undefined name 'filepath'
py4DSTEM/io/native/read/read_v0_6.py:205:23: F821 undefined name 'filepath'
py4DSTEM/io/native/read/read_v0_12.py:84:20: F821 undefined name 'metadata_from_h5'
py4DSTEM/io/native/metadata/h5rw.py:204:24: F821 undefined name '_store_pickle'
py4DSTEM/visualize/show.py:354:9: F821 undefined name 'add_grid_overly'
py4DSTEM/visualize/show.py:354:28: F821 undefined name 'grid'
py4DSTEM/visualize/show.py:469:28: F821 undefined name 'grid'
py4DSTEM/visualize/show.py:527:23: F821 undefined name 'bins_edges'
py4DSTEM/visualize/vis_special.py:516:26: F821 undefined name 'ax'
py4DSTEM/gui/gui_utils.py:72:12: F821 undefined name 'get_py4DSTEM_dataobject_info'
py4DSTEM/gui/gui_utils.py:73:12: F821 undefined name 'np'
py4DSTEM/gui/gui_utils.py:223:30: F821 undefined name 'QtWidget'
py4DSTEM/process/calibration/ellipse.py:660:5: F821 undefined name 'plt'
py4DSTEM/process/calibration/ellipse.py:661:5: F821 undefined name 'plt'
py4DSTEM/process/calibration/ellipse.py:708:18: F821 undefined name 'polar'
py4DSTEM/process/calibration/ellipse.py:709:19: F821 undefined name 'polar'
py4DSTEM/process/calibration/ellipse.py:722:51: F821 undefined name 'background1D'
py4DSTEM/process/preprocess/electroncount.py:196:64: F821 undefined name 'torch_'
py4DSTEM/process/preprocess/electroncount.py:311:17: F821 undefined name 'torch'
py4DSTEM/process/preprocess/electroncount.py:395:16: F821 undefined name 'dm'
py4DSTEM/process/preprocess/electroncount.py:395:28: F821 undefined name 'dm4filename'
py4DSTEM/process/preprocess/electroncount.py:410:33: F821 undefined name 'DataCube'
py4DSTEM/process/preprocess/electroncount.py:410:47: F821 undefined name 'counted'
py4DSTEM/process/preprocess/electroncount.py:412:19: F821 undefined name 'dm4filename'
py4DSTEM/process/preprocess/electroncount.py:413:5: F821 undefined name 'save'
py4DSTEM/process/preprocess/relativity.py:172:2: F821 undefined name 'display'
py4DSTEM/process/diskdetection/diskdetection.py:662:18: F821 undefined name 'minPeakSpacing'
py4DSTEM/process/dpc/dpc.py:396:13: F821 undefined name 'make_qspace_coords'
```

The overwhelming majority of these errors are just typos, or using an obviously wrong variable name, and so are trivial to correct. There were some places where an import was missing in the appropriate scope. 

In `gui_utils.py` there were the beginnings of a function that would have given the user a way to select a single datacube from a file with several of them. But it was never completed, its structure depended on features of the old `FileBrowser` to work smartly, and it was not called from anywhere else in the code. So I have cut that function out entirely, and we can revisit it in the future if we decide to add this feature. 

In `dpc.py` there was a reference to some kind of custom Fourier coords function, which I think was removed at some point (or maybe never existed?). I replaced that with a numpy function, though I am not 100% sure that it is correct (and since there is no evidence of the original function it called, I have no way to check). 

After making these changes, there are still a few linter errors that I cannot figure out how to solve, all of which live in `ellipse.py` and so I imagine will be solved by up-and-coming PRs addressing that corner of our little pythonic world.
```
$ flake8 --select=F402,F404,F812,F823,F831,F821,F822,E112,E113,E901,E902,E999 py4DSTEM
py4DSTEM/process/calibration/ellipse.py:709:18: F821 undefined name 'polar'
py4DSTEM/process/calibration/ellipse.py:710:19: F821 undefined name 'polar'
py4DSTEM/process/calibration/ellipse.py:723:51: F821 undefined name 'background1D'
```