### PR TITLE
small bugfixes for ACOM PR

### DIFF
--- a/py4DSTEM/process/calibration/origin.py
+++ b/py4DSTEM/process/calibration/origin.py
@@ -348,7 +348,7 @@ def get_origin_brightest_disk(
 
     return qx0_ar, qy0_ar
 
-def get_origin_single_dp_beamstop(DP,mask):
+def get_origin_single_dp_beamstop(DP: np.ndarray,mask: np.ndarray):
     """
     Find the origin for a single diffraction pattern, assuming there is a beam stop.
 
@@ -387,7 +387,7 @@ def get_origin_beamstop(datacube: DataCube, mask: np.ndarray):
         mask (np array): boolean mask which is False under the beamstop and True
             in the diffraction pattern. One approach to generating this mask
             is to apply a suitable threshold on the average diffraction pattern
-            and use binary opening/closing to remove and holes
+            and use binary opening/closing to remove any holes
 
     Returns:
         qx0, qy0 (tuple of np arrays) measured center position of each diffraction pattern
@@ -398,6 +398,9 @@ def get_origin_beamstop(datacube: DataCube, mask: np.ndarray):
 
     for rx, ry in tqdmnd(datacube.R_Nx, datacube.R_Ny):
         x, y = get_origin_single_dp_beamstop(datacube.data[rx, ry, :, :], mask)
+
+        qx0[rx,ry] = x
+        qy0[rx,ry] = y
 
     return qx0, qy0
 

--- a/py4DSTEM/process/diffraction/crystal.py
+++ b/py4DSTEM/process/diffraction/crystal.py
@@ -2634,7 +2634,7 @@ class Crystal:
             foil_normal = zone_axis
         else:
             foil_normal = np.asarray(foil_normal, dtype="float")
-            if not cartesian_directions:
+            if not self.cartesian_directions:
                 foil_normal = self.crystal_to_cartesian(foil_normal)
             else:
                 foil_normal = foil_normal / np.linalg.norm(foil_normal)


### PR DESCRIPTION
Somehow, presumably when I was merging things a while ago, some of the functionality of the beamstop center finding function got lost. This PR fixes that error.

There was also a syntax error in crystal.py, where `cartesian_directions` was referenced instead of `self.cartesian_directions`, which I have fixed. 

Running the linter on `crystal.py` also shows an error on line 2513 in `match_single_pattern` when `plot_corr_3D` is True, where an undefined name `corr` is used, but I can't tell by quick inspection what this name is supposed to be referring to. 