### PR TITLE
Make BraggVectorMaps ~150x faster

### DIFF
--- a/py4DSTEM/process/diskdetection/braggvectormap.py
+++ b/py4DSTEM/process/diskdetection/braggvectormap.py
@@ -32,7 +32,7 @@ def get_bragg_vector_map(braggpeaks, Q_Nx, Q_Ny):
     ceily = np.ceil(qy).astype(np.int64)
     
     # Remove any points outside [0, Q_Nx] & [0, Q_Ny]
-    mask = np.logical_and(np.logical_and(np.logical_and((floorx>=0),(floory>=0)),(ceilx<Q_Nx)),(ceily<Q_Ny))
+    mask = np.logical_and.reduce(((floorx>=0),(floory>=0),(ceilx<Q_Nx),(ceily<Q_Ny)))
     qx = qx[mask]
     qy = qy[mask]
     I = I[mask]
@@ -152,7 +152,7 @@ def get_bragg_vector_map_raw(braggpeaks, Q_Nx, Q_Ny):
     ceily = np.ceil(qy).astype(np.int64)
     
     # Remove any points outside [0, Q_Nx] & [0, Q_Ny]
-    mask = np.logical_and(np.logical_and(np.logical_and((floorx>=0),(floory>=0)),(ceilx<Q_Nx)),(ceily<Q_Ny))
+    mask = np.logical_and.reduce(((floorx>=0),(floory>=0),(ceilx<Q_Nx),(ceily<Q_Ny)))
     qx = qx[mask]
     qy = qy[mask]
     I = I[mask]

--- a/py4DSTEM/process/diskdetection/braggvectormap.py
+++ b/py4DSTEM/process/diskdetection/braggvectormap.py
@@ -19,17 +19,48 @@ def get_bragg_vector_map(braggpeaks, Q_Nx, Q_Ny):
     """
     assert np.all([name in braggpeaks.dtype.names for name in ['qx','qy','intensity']]), "braggpeaks coords must include coordinates: 'qx', 'qy', 'intensity'."
 
-    braggvectormap = np.zeros((Q_Nx,Q_Ny))
-    qx0,qy0 = Q_Nx/2.,Q_Ny/2.
-    for (Rx, Ry) in tqdmnd(braggpeaks.shape[0],braggpeaks.shape[1],
-                           desc='Computing Bragg vector map',unit='DP',unit_scale=True):
-        peaks = braggpeaks.get_pointlist(Rx,Ry)
-        for i in range(peaks.length):
-            qx = peaks.data['qx'][i]+qx0
-            qy = peaks.data['qy'][i]+qy0
-            I = peaks.data['intensity'][i]
-            braggvectormap = add_to_2D_array_from_floats(braggvectormap,qx,qy,I)
-    return braggvectormap
+    # Concatenate all PointList data together for speeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeed
+    bigpl = np.concatenate([pl.data for subpl in braggpeaks.pointlists for pl in subpl])
+    qx = bigpl['qx'] + (Q_Nx/2.)
+    qy = bigpl['qy'] + (Q_Ny/2.)
+    I = bigpl['intensity']
+    
+    # Precompute rounded coordinates
+    floorx = np.floor(qx).astype(np.int64)
+    ceilx = np.ceil(qx).astype(np.int64)
+    floory = np.floor(qy).astype(np.int64)
+    ceily = np.ceil(qy).astype(np.int64)
+    
+    # Remove any points outside [0, Q_Nx] & [0, Q_Ny]
+    mask = np.logical_and(np.logical_and(np.logical_and((floorx>=0),(floory>=0)),(ceilx<Q_Nx)),(ceily<Q_Ny))
+    qx = qx[mask]
+    qy = qy[mask]
+    I = I[mask]
+    floorx = floorx[mask]
+    floory = floory[mask]
+    ceilx = ceilx[mask]
+    ceily = ceily[mask]
+    
+    dx = qx - floorx
+    dy = qy - floory
+
+    # Compute indices of the 4 neighbors to (qx,qy)
+    # floor x, floor y
+    inds00 = np.ravel_multi_index([floorx,floory],(Q_Nx,Q_Ny)) 
+    # floor x, ceil y
+    inds01 = np.ravel_multi_index([floorx,ceily],(Q_Nx,Q_Ny))
+    # ceil x, floor y
+    inds10 = np.ravel_multi_index([ceilx,floory],(Q_Nx,Q_Ny))
+    # ceil x, ceil y
+    inds11 = np.ravel_multi_index([ceilx,ceily],(Q_Nx,Q_Ny))
+    
+    # Compute the BVM by accumulating intensity in each neighbor weighted by linear interpolation
+    bvm = (np.bincount(inds00, I * (1.-dx) * (1.-dy), minlength=Q_Nx*Q_Ny) + \
+            np.bincount(inds01, I * (1.-dx) * dy, minlength=Q_Nx*Q_Ny) + \
+            np.bincount(inds10, I * dx * (1.-dy), minlength=Q_Nx*Q_Ny) + \
+            np.bincount(inds11, I * dx * dy, minlength=Q_Nx*Q_Ny)).reshape(Q_Nx,Q_Ny)
+    
+    return bvm
 
 def get_bragg_vector_maxima_map(braggpeaks, Q_Nx, Q_Ny):
     """
@@ -109,16 +140,48 @@ def get_bragg_vector_map_raw(braggpeaks, Q_Nx, Q_Ny):
     """
     assert np.all([name in braggpeaks.dtype.names for name in ['qx','qy','intensity']]), "braggpeaks coords must include coordinates: 'qx', 'qy', 'intensity'."
 
-    braggvectormap = np.zeros((Q_Nx,Q_Ny))
-    for (Rx, Ry) in tqdmnd(braggpeaks.shape[0],braggpeaks.shape[1],
-                           desc='Computing Bragg vector map',unit='DP',unit_scale=True):
-        peaks = braggpeaks.get_pointlist(Rx,Ry)
-        for i in range(peaks.length):
-            qx = peaks.data['qx'][i]
-            qy = peaks.data['qy'][i]
-            I = peaks.data['intensity'][i]
-            braggvectormap = add_to_2D_array_from_floats(braggvectormap,qx,qy,I)
-    return braggvectormap
+    # Concatenate all PointList data together for speeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeed
+    bigpl = np.concatenate([pl.data for subpl in braggpeaks.pointlists for pl in subpl])
+    qx = bigpl['qx']
+    qy = bigpl['qy']
+    I = bigpl['intensity']
+    
+    # Precompute rounded coordinates
+    floorx = np.floor(qx).astype(np.int64)
+    ceilx = np.ceil(qx).astype(np.int64)
+    floory = np.floor(qy).astype(np.int64)
+    ceily = np.ceil(qy).astype(np.int64)
+    
+    # Remove any points outside [0, Q_Nx] & [0, Q_Ny]
+    mask = np.logical_and(np.logical_and(np.logical_and((floorx>=0),(floory>=0)),(ceilx<Q_Nx)),(ceily<Q_Ny))
+    qx = qx[mask]
+    qy = qy[mask]
+    I = I[mask]
+    floorx = floorx[mask]
+    floory = floory[mask]
+    ceilx = ceilx[mask]
+    ceily = ceily[mask]
+    
+    dx = qx - floorx
+    dy = qy - floory
+
+    # Compute indices of the 4 neighbors to (qx,qy)
+    # floor x, floor y
+    inds00 = np.ravel_multi_index([floorx,floory],(Q_Nx,Q_Ny)) 
+    # floor x, ceil y
+    inds01 = np.ravel_multi_index([floorx,ceily],(Q_Nx,Q_Ny))
+    # ceil x, floor y
+    inds10 = np.ravel_multi_index([ceilx,floory],(Q_Nx,Q_Ny))
+    # ceil x, ceil y
+    inds11 = np.ravel_multi_index([ceilx,ceily],(Q_Nx,Q_Ny))
+    
+    # Compute the BVM by accumulating intensity in each neighbor weighted by linear interpolation
+    bvm = (np.bincount(inds00, I * (1.-dx) * (1.-dy), minlength=Q_Nx*Q_Ny) + \
+            np.bincount(inds01, I * (1.-dx) * dy, minlength=Q_Nx*Q_Ny) + \
+            np.bincount(inds10, I * dx * (1.-dy), minlength=Q_Nx*Q_Ny) + \
+            np.bincount(inds11, I * dx * dy, minlength=Q_Nx*Q_Ny)).reshape(Q_Nx,Q_Ny)
+    
+    return bvm
 
 def get_bragg_vector_maxima_map_raw(braggpeaks, Q_Nx, Q_Ny):
     """

--- a/py4DSTEM/process/diskdetection/braggvectormap.py
+++ b/py4DSTEM/process/diskdetection/braggvectormap.py
@@ -115,11 +115,10 @@ def get_weighted_bragg_vector_map(braggpeaks, Q_Nx, Q_Ny, weights):
                            desc='Computing Bragg vector map',unit='DP',unit_scale=True):
         if weights[Rx,Ry] != 0:
             peaks = braggpeaks.get_pointlist(Rx,Ry)
-            for i in range(peaks.length):
-                qx = peaks.data['qx'][i]+qx0
-                qy = peaks.data['qy'][i]+qy0
-                I = peaks.data['intensity'][i]
-                braggvectormap = add_to_2D_array_from_floats(braggvectormap,qx,qy,I*weights[Rx,Ry])
+            qx = peaks.data['qx']+qx0
+            qy = peaks.data['qy']+qy0
+            I = peaks.data['intensity']
+            add_to_2D_array_from_floats(braggvectormap,qx,qy,I*weights[Rx,Ry])
     return braggvectormap
 
 
@@ -232,11 +231,10 @@ def get_weighted_bragg_vector_map_raw(braggpeaks, Q_Nx, Q_Ny, weights):
                            desc='Computing Bragg vector map',unit='DP',unit_scale=True):
         if weights[Rx,Ry] != 0:
             peaks = braggpeaks.get_pointlist(Rx,Ry)
-            for i in range(peaks.length):
-                qx = peaks.data['qx'][i]
-                qy = peaks.data['qy'][i]
-                I = peaks.data['intensity'][i]
-                braggvectormap = add_to_2D_array_from_floats(braggvectormap,qx,qy,I*weights[Rx,Ry])
+            qx = peaks.data['qx']
+            qy = peaks.data['qy']
+            I = peaks.data['intensity']
+            braggvectormap = add_to_2D_array_from_floats(braggvectormap,qx,qy,I*weights[Rx,Ry])
     return braggvectormap
 
 

--- a/py4DSTEM/process/utils/utils.py
+++ b/py4DSTEM/process/utils/utils.py
@@ -456,6 +456,9 @@ def add_to_2D_array_from_floats(ar, x, y, I):
     """
     Adds the values I to array ar, distributing the value between the four pixels nearest
     (x,y) using linear interpolation.  Inputs (x,y,I) may be floats or arrays of floats.
+
+    Note that if the same [x,y] coordinate appears more than once in the input array,
+    only the *final* value of I at that coordinate will get added.
     """
     Nx, Ny = ar.shape
     x0, x1 = (np.floor(x)).astype(int), (np.ceil(x)).astype(int)


### PR DESCRIPTION
Previously we were calling `add_to_2D_array_from_floats` once _per point_ in making Bragg vector maps! Even though `add_to_2D_array_from_floats` was vectorized!

Anywho, I have replaced those nested for loops with concatenation of all of the PointLists together followed by one single accumulation of the intensity at each coordinate using `np.bincount`. `add_to_2D_array_from_floats` won't work correctly if there is more than one point at the same (qx,qy) location, which was fine when it was called once per PointList (or per point!) but would obviously cause problems when doing all the points at once. 

In my testing this new version is consistently ~150x faster than previously, regardless of the size of the data. For a very large PLA from a 512x512x512x512 scan that I have on hand, the BVM generation time went down from 119s to 0.737s.

This speedup applies to `get_Bragg_vector_map` and `get_bragg_vector_map_raw` only. Initially I had reworked `add_to_2D_array_from_floats` using the `np.bincount` based implementation, but for very small inputs (a few points), this could be substantially slower than previously! So instead I have just removed the inner for loop for a ~10x speedup on the weighted BVM functions. One could also rework those to include the weights in the concatenation step, somehow, for the full speedup.

The maximal BVM functions are untouched. 