### PR TITLE
Improve tqdmnd documentation

### DIFF
--- a/py4DSTEM/process/utils/tqdmnd.py
+++ b/py4DSTEM/process/utils/tqdmnd.py
@@ -20,20 +20,55 @@ from numpy import integer
 
 from collections.abc import Iterator
 
+
 class nditer(Iterator):
-    def __init__(self,*args):
+    def __init__(self, *args):
         if len(args) > 1:
             self._it = product(*args)
         else:
             self._it = args[0]
-        self._l = reduce(mul,[a.__len__() for a in args])
+        self._l = reduce(mul, [a.__len__() for a in args])
+
     def __iter__(self):
         return self._it.__iter__()
+
     def __next__(self):
         return self._it.__next__()
+
     def __len__(self):
         return self._l
 
-def tqdmnd(*args,**kwargs):
-    r = [range(i) if isinstance(i,(int,integer)) else i for i in args]
-    return tqdm(nditer(*r),**kwargs)
+
+def tqdmnd(*args, **kwargs):
+    """
+    An N-dimensional extension of tqdm providing an iterator and
+    progress bar over the product of multiple iterations.
+
+    Example Usage:
+        for rx, ry in tqdmnd(datacube.R_Nx, datacube.R_Ny):
+            data[rx,ry] = ...
+    is equivalent to the following, while also providing a progress bar:
+        for rx in range(datacube.R_Nx):
+            for ry in range(datacube.R_Ny):
+                data[rx,ry] = ...
+
+    Accepts:
+        *args:  Any number of iterators. The Cartesian product of these
+                iterators is returned. Any integers I passed as arguments
+                will be converted to range(I). The input iterators must
+                have a known length.
+        **kwargs: keyword arguments are passed through directly to tqdm.
+                Full details are available at https://tqdm.github.io
+                Some useful ones you'll encounter in py4DSTEM are:
+                    disable (bool): hide the progress bar when True
+                    keep (bool): delete the progress bar after completion when True
+                    unit (str): pretty unit name for the display of iteration speed
+                    unit_scale (bool): whether to scale the displayed units and add SI prefixes
+                    desc (str): message displayed in front of the progress bar
+
+    Returns:
+        At each iteration, a tuple of indices is returned, corresponding to the 
+        values of each input iterator (in the same order as the inputs). 
+    """
+    r = [range(i) if isinstance(i, (int, integer)) else i for i in args]
+    return tqdm(nditer(*r), **kwargs)

--- a/py4DSTEM/process/utils/tqdmnd.py
+++ b/py4DSTEM/process/utils/tqdmnd.py
@@ -54,10 +54,10 @@ def tqdmnd(*args, **kwargs):
 
     Accepts:
         *args:  Any number of iterators. The Cartesian product of these
-                iterators is returned. Any integers I passed as arguments
-                will be converted to range(I). The input iterators must
+                iterators is returned. Any integers `I` passed as arguments
+                will be interpreted as `range(I)`. The input iterators must
                 have a known length.
-        **kwargs: keyword arguments are passed through directly to tqdm.
+        **kwargs: keyword arguments passed through directly to tqdm.
                 Full details are available at https://tqdm.github.io
                 Some useful ones you'll encounter in py4DSTEM are:
                     disable (bool): hide the progress bar when True

--- a/py4DSTEM/process/utils/tqdmnd.py
+++ b/py4DSTEM/process/utils/tqdmnd.py
@@ -42,7 +42,7 @@ class nditer(Iterator):
 def tqdmnd(*args, **kwargs):
     """
     An N-dimensional extension of tqdm providing an iterator and
-    progress bar over the product of multiple iterations.
+    progress bar over the product of multiple iterators.
 
     Example Usage:
         for rx, ry in tqdmnd(datacube.R_Nx, datacube.R_Ny):


### PR DESCRIPTION
Since some PR review comments brought up `tqdmnd` being undocumented, I went back and checked and noticed that the documentation was at the top of the file rather than in a docstring. So I have added a docstring to the function itself and expanded on that a bit. 