### PR TITLE
removing rogue import that doesn't exist.

### DIFF
--- a/py4DSTEM/process/diskdetection/diskdetection_parallel_new.py
+++ b/py4DSTEM/process/diskdetection/diskdetection_parallel_new.py
@@ -1,4 +1,3 @@
-from py4DSTEM.process.utils.ellipticalCoords import compare_double_sided_gaussian
 import py4DSTEM
 import numpy as np
 import matplotlib.pyplot as plt


### PR DESCRIPTION
`from py4DSTEM.process.utils.ellipticalCoords import compare_double_sided_gaussian` was added  to `diskdetection_parallel_new.py` but not used and doesn't exist. So I've removed it