### PR TITLE
Relax PyQt5 version requirement for conda-forge purposes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'matplotlib >= 3.4.2',
         'scikit-image >= 0.17.2',
         'scikit-learn >= 0.23.2',
-        'PyQt5 >= 5.13',
+        'PyQt5 >= 5.10',
         'pyqtgraph >= 0.11',
         'qtconsole >= 4.7.7',
         'ipywidgets >= 7.6.3',


### PR DESCRIPTION
It appears that the latest distribution of PyQt5 available on conda-forge is 5.12, and there is reason to think that it will remain out-of-date for some time. This version conflict seems to be the final hurdle to getting our own conda-forge recipe building again, so this PR simply changes the Qt requirement from 5.13 to 5.10.

Once this gets propagated into main, I will PR the conda-forge recipe with the appropriate tweaks to get a distribution there running.