### PR TITLE
Fixes model being left open after reading

### DIFF
--- a/py4DSTEM/process/diskdetection/diskdetection_aiml.py
+++ b/py4DSTEM/process/diskdetection/diskdetection_aiml.py
@@ -752,16 +752,16 @@ def _get_latest_model(model_path = None):
             pass
         
         download_file_from_google_drive('1cmobCAp63gLuPMlRvYTj7tBX0ZbmXM9T','./tmp/model_metadata.json')
-        f = open('./tmp/model_metadata.json')
-        metadata = json.load(f)
-        file_id = metadata['file_id']
-        file_path = metadata['file_path']
-        file_type = metadata['file_type']
+        with open('./tmp/model_metadata.json') as f:
+            metadata = json.load(f)
+            file_id = metadata['file_id']
+            file_path = metadata['file_path']
+            file_type = metadata['file_type']
         
         try:
-            f_old = open('./tmp/model_metadata_old.json')
-            metaold = json.load(f_old)
-            file_id_old = metaold['file_id']
+            with open('./tmp/model_metadata_old.json') as f_old:
+                metaold = json.load(f_old)
+                file_id_old = metaold['file_id']
         except:
             file_id_old = file_id
         


### PR DESCRIPTION
While trying to follow the demo of [py4dstem[aiml]](https://github.com/py4dstem/py4DSTEM_tutorials/blob/main/notebooks/strain_aiml/experiment_Si_SiGe_multilayer_mlai.ipynb) I kept running into the following error: 
`PermissionError: [WinError 32] The process cannot access the file because it is being used by another process.`. 
This error was caused inside the `_get_latest_model()` function in [line 771](https://github.com/py4dstem/py4DSTEM/blob/9e86bddaac0b46f91c1c2a46c604736580ea9d78/py4DSTEM/process/diskdetection/diskdetection_aiml.py#L771) because the temporary `model_metadata.json` and `model_metadata_old.json` files were left open in previous lines.

Changes made:

- [x] Added the `with open(str) as f:` syntax instead.

I believe this is a better syntax and may help new users like me to experiment with the new py4DSTEM[aiml]. 
If not correct, please discard and close this PR.