### PR TITLE
Small fixes to Crystal and fix a typo

### DIFF
--- a/py4DSTEM/process/diffraction/crystal.py
+++ b/py4DSTEM/process/diffraction/crystal.py
@@ -322,6 +322,17 @@ class Crystal:
 
         return Crystal.from_pymatgen_structure(structure)
 
+    def setup_diffraction(
+        self, accelerating_voltage: float, cartesian_directions: bool = True
+    ):
+        """
+        Set up attributes used for diffraction calculations without going
+        through the full ACOM pipeline.
+        """
+        self.accel_voltage = accelerating_voltage
+        self.wavelength = electron_wavelength_angstrom(self.accel_voltage)
+        self.cartesian_directions = cartesian_directions
+
     def calculate_structure_factors(
         self,
         k_max: float = 2.0,

--- a/py4DSTEM/process/diffraction/crystal.py
+++ b/py4DSTEM/process/diffraction/crystal.py
@@ -59,8 +59,8 @@ class Crystal:
         #: atomic numbers - if only one value is provided, assume all atoms are same species
         numbers = np.asarray(numbers, dtype="intp")
         if np.size(numbers) == 1:
-            self.numbers = np.ones(positions.shape[0], dtype="intp") * numbers
-        elif np.size(numbers) == positions.shape[0]:
+            self.numbers = np.ones(self.positions.shape[0], dtype="intp") * numbers
+        elif np.size(numbers) == self.positions.shape[0]:
             self.numbers = numbers
         else:
             raise Exception("Number of positions and atomic numbers do not match")

--- a/py4DSTEM/process/preprocess/radialbkgrd.py
+++ b/py4DSTEM/process/preprocess/radialbkgrd.py
@@ -63,8 +63,8 @@ def get_1D_polar_background(data,
 
     # Crop polar data to maximum distance which contains information from original image
     if (polarData.mask.sum(axis = (0))==polarData.shape[0]).any():
-            ii = polar.data.shape[1]
-            while(polar.mask[:,ii].all()==True):
+            ii = polarData.data.shape[1]
+            while(polarData.mask[:,ii].all()==True):
                 ii = ii-1
             maximalDistance = ii
             polarData = polarData[:,0:maximalDistance]


### PR DESCRIPTION
This makes some little tweaks in Crystal and also fixed a typo in the polar background code. The Crystal fixes add a function that lets you set the accelerating voltage and the cartesian flag (which otherwise would require running certain ACOM or Bloch functions) and fix a bug where lists were not getting converted to numpy arrays at the right time. 