### PR TITLE
Batch FFTs in CUDA disk detection

### DIFF
--- a/py4DSTEM/process/diskdetection/diskdetection.py
+++ b/py4DSTEM/process/diskdetection/diskdetection.py
@@ -486,8 +486,8 @@ def find_Bragg_disks(datacube, probe,
                 * cluster_path (str): defaults to the working directory during processing
             if distributed is None, which is the default, processing will be in serial
         CUDA (bool): If True, import cupy and use an NVIDIA GPU to perform disk detection
-        CUDA_batching (bool): If True, and CUDA is selected, FFTs will be batched for greater
-            performance when using a relatively capable GPU. 
+        CUDA_batched (bool): If True, and CUDA is selected, the FFT and IFFT steps of
+            disk detection are performed in batches to better utilize GPU resources. 
 
     Returns:
         (PointListArray): the Bragg peak positions and correlation intensities

--- a/py4DSTEM/process/diskdetection/diskdetection.py
+++ b/py4DSTEM/process/diskdetection/diskdetection.py
@@ -432,7 +432,8 @@ def find_Bragg_disks(datacube, probe,
                      filter_function = None,
                      _qt_progress_bar = None,
                      distributed = None,
-                     CUDA = False):
+                     CUDA = False,
+                     CUDA_batched = True,):
     """
     Finds the Bragg disks in all diffraction patterns of datacube by cross, hybrid, or
     phase correlation with probe.
@@ -484,6 +485,9 @@ def find_Bragg_disks(datacube, probe,
                   file containing the datacube
                 * cluster_path (str): defaults to the working directory during processing
             if distributed is None, which is the default, processing will be in serial
+        CUDA (bool): If True, import cupy and use an NVIDIA GPU to perform disk detection
+        CUDA_batching (bool): If True, and CUDA is selected, FFTs will be batched for greater
+            performance when using a relatively capable GPU. 
 
     Returns:
         (PointListArray): the Bragg peak positions and correlation intensities
@@ -580,7 +584,8 @@ def find_Bragg_disks(datacube, probe,
                 upsample_factor=upsample_factor,
                 name=name,
                 filter_function=filter_function,
-                _qt_progress_bar=_qt_progress_bar)
+                _qt_progress_bar=_qt_progress_bar,
+                batching=CUDA_batched)
 
     elif isinstance(distributed, dict):
         connect, data_file, cluster_path = _parse_distributed(distributed)

--- a/py4DSTEM/process/diskdetection/diskdetection_cuda.py
+++ b/py4DSTEM/process/diskdetection/diskdetection_cuda.py
@@ -129,9 +129,11 @@ def find_Bragg_disks_CUDA(
 
     t0 = time()
     if batching:
-        # estimate the max batch size: (this is probably wrong)
+        # compute the batch size based on available VRAM:
         max_num_bytes = cp.cuda.Device().mem_info[0]
-        batch_size = max_num_bytes // (bytes_per_pattern * 10) # what should this fudge factor be?
+        # use a fudge factor to keep the batches smaller, which 
+        # seems to result in slightly better performance
+        batch_size = max_num_bytes // (bytes_per_pattern * 10)
         num_batches = datacube.R_N // batch_size + 1
 
         print(f"Using {num_batches} batches of {batch_size} patterns each...")

--- a/py4DSTEM/process/latticevectors/index.py
+++ b/py4DSTEM/process/latticevectors/index.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.linalg import lstsq
 
 from ...io import PointList, PointListArray
+from ..utils import tqdmnd
 
 def get_selected_lattice_vectors(gx,gy,i0,i1,i2):
     """
@@ -201,22 +202,21 @@ def add_indices_to_braggpeaks(braggpeaks, lattice, maxPeakSpacing, qx_shift=0,
         indexed_braggpeaks = indexed_braggpeaks.add_coordinates([('k',int)])
 
     # loop over all the scan positions
-    for Rx in range(mask.shape[0]):
-        for Ry in range(mask.shape[1]):
-            if mask[Rx,Ry]:
-                pl = indexed_braggpeaks.get_pointlist(Rx,Ry)
-                rm_peak_mask = np.zeros(pl.length,dtype=bool)
+    for Rx, Ry in tqdmnd(mask.shape[0],mask.shape[1]):
+        if mask[Rx,Ry]:
+            pl = indexed_braggpeaks.get_pointlist(Rx,Ry)
+            rm_peak_mask = np.zeros(pl.length,dtype=bool)
 
-                for i in range(pl.length):
-                    r2 = (pl.data['qx'][i]-lattice.data['qx'] + qx_shift)**2 + \
-                         (pl.data['qy'][i]-lattice.data['qy'] + qy_shift)**2
-                    ind = np.argmin(r2)
-                    if r2[ind] <= maxPeakSpacing**2:
-                        pl.data['h'][i] = lattice.data['h'][ind]
-                        pl.data['k'][i] = lattice.data['k'][ind]
-                    else:
-                        rm_peak_mask[i] = True
-                pl.remove_points(rm_peak_mask)
+            for i in range(pl.length):
+                r2 = (pl.data['qx'][i]-lattice.data['qx'] + qx_shift)**2 + \
+                     (pl.data['qy'][i]-lattice.data['qy'] + qy_shift)**2
+                ind = np.argmin(r2)
+                if r2[ind] <= maxPeakSpacing**2:
+                    pl.data['h'][i] = lattice.data['h'][ind]
+                    pl.data['k'][i] = lattice.data['k'][ind]
+                else:
+                    rm_peak_mask[i] = True
+            pl.remove_points(rm_peak_mask)
 
     indexed_braggpeaks.name = braggpeaks.name + "_indexed"
     return indexed_braggpeaks


### PR DESCRIPTION
This adds an optimization to the CUDA Bragg disk detection routine, which is to perform the FFT and probe kernel multiplication step on several diffraction patterns at once on the GPU to better utilize resources. This gives approximately a 60% speedup over the previous CUDA method on my RTX3090.

With a 112x160x864x864 dataset, the performance on my workstation is:
* CPU only: 7.80 DP/s
* CUDA (previous): 66.4 DP/s
* CUDA (with batching): 110.3 DP/s

I have checked that it gives the same results as the old version, and as the CPU version. 

There is also a tweak to the K2 data reader, which theoretically allows it to handle data files that do not begin with a sync byte, which I include here half because it's so small of a change that it doesn't warrant its own PR and half because I forgot it's in my dev branch. 