### PR TITLE
Bloch wave helper function integration

### DIFF
--- a/py4DSTEM/process/diffraction/crystal.py
+++ b/py4DSTEM/process/diffraction/crystal.py
@@ -345,7 +345,7 @@ class Crystal:
         return Crystal.from_pymatgen_structure(structure)
 
     def setup_diffraction(
-        self, accelerating_voltage: float, cartesian_directions: bool = True
+        self, accelerating_voltage: float
     ):
         """
         Set up attributes used for diffraction calculations without going
@@ -353,7 +353,6 @@ class Crystal:
         """
         self.accel_voltage = accelerating_voltage
         self.wavelength = electron_wavelength_angstrom(self.accel_voltage)
-        self.cartesian_directions = cartesian_directions
 
     def calculate_structure_factors(
         self,
@@ -462,10 +461,10 @@ class Crystal:
         zone_axis_cartesian: Optional[np.ndarray] = None,
         proj_x_cartesian: Optional[np.ndarray] = None,
         foil_normal_cartesian: Optional[Union[list, tuple, np.ndarray]] = None,
-        accel_voltage = None,
         sigma_excitation_error: float = 0.02,
         tol_excitation_error_mult: float = 3,
         tol_intensity: float = 1e-4,
+        k_max: Optional[float] = None,
         keep_qz = False,
         return_orientation_matrix=False,
     ):
@@ -500,17 +499,6 @@ class Crystal:
 
         # Tolerance for angular tests
         tol = 1e-6
-
-        # init voltage and wavelength if needed
-        if accel_voltage is not None:
-            self.accel_voltage = np.asarray(accel_voltage)
-        else:
-            # Check if voltage already exists, if not set to 300 kV
-            if not hasattr(self, 'accel_voltage'):
-                self.accel_voltage = 300.0e3
-
-                # Calculate wavelength
-                self.wavelength = electron_wavelength_angstrom(self.accel_voltage)
 
         # Parse orientation inputs
         if orientation is not None:
@@ -549,6 +537,12 @@ class Crystal:
         # Threshold for inclusion in diffraction pattern
         sg_max = sigma_excitation_error * tol_excitation_error_mult
         keep = np.abs(sg) <= sg_max
+
+        # Maximum scattering angle cutoff
+        if k_max is not None:
+            keep_kmax = np.linalg.norm(g,axis=0) <= k_max
+            keep = np.logical_and(keep, keep_kmax)
+
         g_diff = g[:, keep]
 
         # Diffracted peak intensities and labels

--- a/py4DSTEM/process/diffraction/crystal.py
+++ b/py4DSTEM/process/diffraction/crystal.py
@@ -722,8 +722,10 @@ class Crystal:
             return (2*g[2,:] - self.wavelength*np.sum(g*g,axis=0)) \
                 / (2 - 2*self.wavelength*g[2,:]) 
         else:
-            return np.nan_to_num((2*g[2,:] - self.wavelength*np.sum(g*g,axis=0)) \
-                / (2*self.wavelength*np.sum(g*foil_normal[:,None],axis=0) - 2*foil_normal[2])) 
+            return (2*g[2,:] - self.wavelength*np.sum(g*g,axis=0)) \
+                / (2*self.wavelength*np.sum(g*foil_normal[:,None],axis=0) - 2*foil_normal[2])
+
+
 
 
 

--- a/py4DSTEM/process/diffraction/crystal.py
+++ b/py4DSTEM/process/diffraction/crystal.py
@@ -722,8 +722,8 @@ class Crystal:
             return (2*g[2,:] - self.wavelength*np.sum(g*g,axis=0)) \
                 / (2 - 2*self.wavelength*g[2,:]) 
         else:
-            return (2*g[2,:] - self.wavelength*np.sum(g*g,axis=0)) \
-                / (2*self.wavelength*np.sum(g*foil_normal[:,None],axis=0) - 2*foil_normal[2]) 
+            return np.nan_to_num((2*g[2,:] - self.wavelength*np.sum(g*g,axis=0)) \
+                / (2*self.wavelength*np.sum(g*foil_normal[:,None],axis=0) - 2*foil_normal[2])) 
 
 
 

--- a/py4DSTEM/process/diffraction/crystal.py
+++ b/py4DSTEM/process/diffraction/crystal.py
@@ -674,10 +674,10 @@ class Crystal:
 
     def parse_orientation(
         self,
-        zone_axis_lattice,
-        proj_x_lattice,
-        zone_axis_cartesian,
-        proj_x_cartesian,
+        zone_axis_lattice=None,
+        proj_x_lattice=None,
+        zone_axis_cartesian=None,
+        proj_x_cartesian=None,
         ):
         # This helper function parse the various types of orientation inputs,
         # and returns the normalized, projected (x,y,z) cartesian vectors in

--- a/py4DSTEM/process/diffraction/crystal_bloch.py
+++ b/py4DSTEM/process/diffraction/crystal_bloch.py
@@ -285,7 +285,7 @@ def generate_dynamical_diffraction_pattern(
     else:
         foil_normal = zone_axis
 
-    foil_normal = foil_normal[:,2]
+    foil_normal = -foil_normal[:,2]
 
     # Note the difference in notation versus kinematic function:
     # k0 is the scalar magnitude of the wavevector, rather than
@@ -339,7 +339,15 @@ def generate_dynamical_diffraction_pattern(
     sg = self.excitation_errors(g.T, foil_normal=foil_normal)
 
     # import matplotlib.pyplot as plt
-    # plt.scatter(g[:,0],g[:,1],np.abs(sg)*100)
+    # sgp = np.sign(sg) >= 0
+    # c = np.zeros_like(g)
+    # c[sgp,:] = np.array([1,0,0])
+    # c[~sgp,:] = np.array([0,0,1])
+    # fig,ax = plt.subplots(dpi=200)
+    # ax.scatter(g[:,0],g[:,1],np.abs(sg)*100,c=c)
+    # ax.axis('equal')
+    # plt.show()
+
 
     # Fill in the diagonal, completing the structure mattrx
     np.fill_diagonal(U_gmh, 2 * k0 * sg + 1.0j * np.imag(self.Ug_dict[(0, 0, 0)]))
@@ -463,6 +471,12 @@ def generate_CBED(
     ZA = np.array(zone_axis[:,2]) / np.linalg.norm(np.array(zone_axis[:,2]))
     proj_x = zone_axis[:,0] / np.linalg.norm(zone_axis[:,0])
     proj_y = zone_axis[:,1] / np.linalg.norm(zone_axis[:,1])
+
+    # the foil normal should be the zone axis if unspecified
+    if foil_normal_lattice is None:
+        foil_normal_lattice = zone_axis_lattice
+    if foil_normal_cartesian is None:
+        foil_normal_cartesian = zone_axis_cartesian
 
     # TODO: refine pixel size to center reflections on pixels
 

--- a/py4DSTEM/process/diffraction/crystal_bloch.py
+++ b/py4DSTEM/process/diffraction/crystal_bloch.py
@@ -336,7 +336,7 @@ def generate_dynamical_diffraction_pattern(
 
     # Compute the diagonal entries of \hat{A}: 2 k_0 s_g [5.51]
     g = (hkl @ self.lat_inv) @ zone_axis
-    sg = self.excitation_errors(g.T, foil_normal=-foil_normal)
+    sg = self.excitation_errors(g.T, foil_normal=-foil_normal @ zone_axis)
 
     # import matplotlib.pyplot as plt
     # sgp = np.sign(sg) >= 0
@@ -479,8 +479,6 @@ def generate_CBED(
         foil_normal_cartesian = zone_axis_cartesian
 
     # TODO: refine pixel size to center reflections on pixels
-    # from pdb import set_trace
-    # set_trace()
 
     # Generate list of plane waves inside aperture
     alpha_pix = np.round(

--- a/py4DSTEM/process/diffraction/crystal_bloch.py
+++ b/py4DSTEM/process/diffraction/crystal_bloch.py
@@ -277,13 +277,13 @@ def generate_dynamical_diffraction_pattern(
     beam_g, beam_h = np.meshgrid(np.arange(n_beams), np.arange(n_beams))
 
     # Parse input orientations:
-    zone_axis = self.parse_orientation(zone_axis_lattice=zone_axis_lattice, 
+    zone_axis_rotation_matrix = self.parse_orientation(zone_axis_lattice=zone_axis_lattice, 
                                        zone_axis_cartesian=zone_axis_cartesian)
     if foil_normal_lattice is not None or foil_normal_cartesian is not None:
         foil_normal = self.parse_orientation(zone_axis_lattice=foil_normal_lattice,
                                              zone_axis_cartesian=foil_normal_cartesian)
     else:
-        foil_normal = zone_axis
+        foil_normal = zone_axis_rotation_matrix
 
     foil_normal = foil_normal[:,2]
 
@@ -335,8 +335,8 @@ def generate_dynamical_diffraction_pattern(
         print(f"Bloch matrix has size {U_gmh.shape}")
 
     # Compute the diagonal entries of \hat{A}: 2 k_0 s_g [5.51]
-    g = (hkl @ self.lat_inv) @ zone_axis
-    sg = self.excitation_errors(g.T, foil_normal=-foil_normal @ zone_axis)
+    g = (hkl @ self.lat_inv) @ zone_axis_rotation_matrix
+    sg = self.excitation_errors(g.T, foil_normal=-foil_normal @ zone_axis_rotation_matrix)
 
     # import matplotlib.pyplot as plt
     # sgp = np.sign(sg) >= 0
@@ -363,7 +363,7 @@ def generate_dynamical_diffraction_pattern(
     t0 = time()  # start timer for eigendecomposition
 
     v, C = linalg.eig(U_gmh)  # decompose!
-    gamma = v / (2.0 * k0 * zone_axis[:,2] @ foil_normal)  # divide by 2 k_n
+    gamma = v / (2.0 * k0 * zone_axis_rotation_matrix[:,2] @ foil_normal)  # divide by 2 k_n
 
     # precompute the inverse of C
     C_inv = np.linalg.inv(C)
@@ -465,12 +465,12 @@ def generate_CBED(
     hkl_proj_y = proj[1] / np.linalg.norm(proj[1])
 
     # get unit vector in zone axis direction and projected x and y Cartesian directions:
-    zone_axis = self.parse_orientation(zone_axis_lattice=zone_axis_lattice,
+    zone_axis_rotation_matrix = self.parse_orientation(zone_axis_lattice=zone_axis_lattice,
                                        zone_axis_cartesian=zone_axis_cartesian,
                                        proj_x_lattice=hkl_proj_x)
-    ZA = np.array(zone_axis[:,2]) / np.linalg.norm(np.array(zone_axis[:,2]))
-    proj_x = zone_axis[:,0] / np.linalg.norm(zone_axis[:,0])
-    proj_y = zone_axis[:,1] / np.linalg.norm(zone_axis[:,1])
+    ZA = np.array(zone_axis_rotation_matrix[:,2]) / np.linalg.norm(np.array(zone_axis_rotation_matrix[:,2]))
+    proj_x = zone_axis_rotation_matrix[:,0] / np.linalg.norm(zone_axis_rotation_matrix[:,0])
+    proj_y = zone_axis_rotation_matrix[:,1] / np.linalg.norm(zone_axis_rotation_matrix[:,1])
 
     # the foil normal should be the zone axis if unspecified
     if foil_normal_lattice is None:

--- a/py4DSTEM/process/diffraction/crystal_bloch.py
+++ b/py4DSTEM/process/diffraction/crystal_bloch.py
@@ -285,7 +285,7 @@ def generate_dynamical_diffraction_pattern(
     else:
         foil_normal = zone_axis
 
-    foil_normal = -foil_normal[:,2]
+    foil_normal = foil_normal[:,2]
 
     # Note the difference in notation versus kinematic function:
     # k0 is the scalar magnitude of the wavevector, rather than
@@ -336,7 +336,7 @@ def generate_dynamical_diffraction_pattern(
 
     # Compute the diagonal entries of \hat{A}: 2 k_0 s_g [5.51]
     g = (hkl @ self.lat_inv) @ zone_axis
-    sg = self.excitation_errors(g.T, foil_normal=foil_normal)
+    sg = self.excitation_errors(g.T, foil_normal=-foil_normal)
 
     # import matplotlib.pyplot as plt
     # sgp = np.sign(sg) >= 0
@@ -479,6 +479,8 @@ def generate_CBED(
         foil_normal_cartesian = zone_axis_cartesian
 
     # TODO: refine pixel size to center reflections on pixels
+    # from pdb import set_trace
+    # set_trace()
 
     # Generate list of plane waves inside aperture
     alpha_pix = np.round(

--- a/py4DSTEM/process/diffraction/crystal_bloch.py
+++ b/py4DSTEM/process/diffraction/crystal_bloch.py
@@ -25,7 +25,6 @@ def calculate_dynamical_structure_factors(
     k_max: float = 2.0,
     thermal_sigma: float = None,
     tol_structure_factor: float = 1.0e-4,
-    cartesian_directions: bool = True,
     verbose=True,
 ):
     """
@@ -208,7 +207,6 @@ def calculate_dynamical_structure_factors(
 
     self.accel_voltage = accelerating_voltage
     self.wavelength = electron_wavelength_angstrom(self.accel_voltage)
-    self.cartesian_directions = cartesian_directions
 
     self.Ug_dict = {
         (hkl[0, i], hkl[1, i], hkl[2, i]): struct_factors[i]


### PR DESCRIPTION
This integrates the new ACOM orientation helper functions into the Bloch wave workflow and uses the new correct calculation of the excitation error. A sample notebook is attached here, and I can PR it into the tutorial repo later
[bloch wave demo.ipynb.zip](https://github.com/py4dstem/py4DSTEM/files/8412382/bloch.wave.demo.ipynb.zip)
 