### PR TITLE
TitanX auto read shape and CUDA fix

### DIFF
--- a/py4DSTEM/io/nonnative/read_dm.py
+++ b/py4DSTEM/io/nonnative/read_dm.py
@@ -51,6 +51,7 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
                     dataSet = dmFile.getDataset(i)
                 i += 1
             dc = DataCube(data=dataSet["data"])
+            _process_NCEM_TitanX_Tags(dmFile, dc)
     elif (mem, binfactor) == ("MEMMAP", 1):
         with dm.fileDM(fp, on_memory=False) as dmFile:
             # loop through the datasets until a >2D one is found:
@@ -62,6 +63,7 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
                     valid_data = True
                 i += 1
             dc = DataCube(data=memmap)
+            _process_NCEM_TitanX_Tags(dmFile, dc)
     elif (mem) == ("RAM"):
         with dm.fileDM(fp, on_memory=True) as dmFile:
             # loop through the datasets until a >2D one is found:
@@ -81,8 +83,13 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
             if rank==4:
                 R_Nx, R_Ny, Q_Nx, Q_Ny = shape
             elif rank==3:
-                R_Nx, Q_Nx, Q_Ny = shape
-                R_Ny = 1
+                titanTags = _process_NCEM_TitanX_Tags(dmFile)
+                if titanTags is not None:
+                    R_Nx, R_Ny = titanTags
+                    Q_Nx, Q_Ny = shape[1:]
+                else:
+                    R_Nx, Q_Nx, Q_Ny = shape
+                    R_Ny = 1
             else:
                 raise Exception(f"Data should be 4-dimensional; found {rank} dimensions")
             Q_Nx, Q_Ny = Q_Nx // binfactor, Q_Ny // binfactor
@@ -106,6 +113,24 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
 
     dc.metadata = md
     return dc
+
+def _process_NCEM_TitanX_Tags(dmFile, dc=None):
+    """
+    Check the metadata in the DM File for certain tags which are added by the NCEM TitanX,
+    and reshape the 3D datacube into 4D using these tags. If no datacube is passed, 
+    return R_Nx and R_Ny
+    """
+    scanx = [v for k,v in dmFile.allTags.items() if "4D STEM Tags.Scan shape X" in k]
+    scany = [v for k,v in dmFile.allTags.items() if "4D STEM Tags.Scan shape Y" in k]
+    if len(scanx) == 1 and len(scany) == 1:
+        # TitanX tags found!
+        R_Nx = int(scanx[0])
+        R_Ny = int(scany[0])
+
+        if dc is not None:
+            dc.set_scan_shape(R_Nx,R_Ny)
+        else:
+            return R_Nx, R_Ny
 
 
 def get_metadata_from_dmFile(fp):

--- a/py4DSTEM/process/diskdetection/kernels.py
+++ b/py4DSTEM/process/diskdetection/kernels.py
@@ -20,8 +20,8 @@ maximal_pts_float32 = r'''
 extern "C" __global__
 void maximal_pts(const float *ar, bool *out, const double minAbsoluteIntensity, const long long sizex, const long long sizey, const long long N){
     int tid = blockDim.x * blockIdx.x + threadIdx.x;
-    int x = tid % sizex;
-    int y = tid / sizey; // Floor divide
+    int x = tid / sizey;
+    int y = tid % sizey;
     bool res = false;
     if (tid < N && x>0 && x<(sizex-1) && y>0 && y<(sizey-1)) {
         float val = ar[tid];
@@ -45,8 +45,8 @@ maximal_pts_float64 = r'''
 extern "C" __global__
 void maximal_pts(const double *ar, bool *out, const double minAbsoluteIntensity, const long long sizex, const long long sizey, const long long N){
     int tid = blockDim.x * blockIdx.x + threadIdx.x;
-    int x = tid % sizex;
-    int y = tid / sizey; // Floor divide
+    int x = tid / sizey;
+    int y = tid % sizey;
     bool res = false;
     if (tid < N && x>0 && x<(sizex-1) && y>0 && y<(sizey-1)) {
         double val = ar[tid];


### PR DESCRIPTION
This PR does two things:
* Add the ability to read the metadata from TitanX datasets and auto-reshape the 3D data to 4D. This corrects a bug where bin-on-load was not possible for TitanX data because the memmap would be 3D.
* Fixes an index computation bug in the CUDA braggdisk detection that would cause illegal memory accesses on non-square data. 