### PR TITLE
read TitanX tags inside DM files and auto-reshape 3D into 4D

### DIFF
--- a/py4DSTEM/io/nonnative/read_dm.py
+++ b/py4DSTEM/io/nonnative/read_dm.py
@@ -51,6 +51,7 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
                     dataSet = dmFile.getDataset(i)
                 i += 1
             dc = DataCube(data=dataSet["data"])
+            _process_NCEM_TitanX_Tags(dmFile, dc)
     elif (mem, binfactor) == ("MEMMAP", 1):
         with dm.fileDM(fp, on_memory=False) as dmFile:
             # loop through the datasets until a >2D one is found:
@@ -62,6 +63,7 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
                     valid_data = True
                 i += 1
             dc = DataCube(data=memmap)
+            _process_NCEM_TitanX_Tags(dmFile, dc)
     elif (mem) == ("RAM"):
         with dm.fileDM(fp, on_memory=True) as dmFile:
             # loop through the datasets until a >2D one is found:
@@ -81,8 +83,13 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
             if rank==4:
                 R_Nx, R_Ny, Q_Nx, Q_Ny = shape
             elif rank==3:
-                R_Nx, Q_Nx, Q_Ny = shape
-                R_Ny = 1
+                titanTags = _process_NCEM_TitanX_Tags(dmFile)
+                if titanTags is not None:
+                    R_Nx, R_Ny = titanTags
+                    Q_Nx, Q_Ny = shape[1:]
+                else:
+                    R_Nx, Q_Nx, Q_Ny = shape
+                    R_Ny = 1
             else:
                 raise Exception(f"Data should be 4-dimensional; found {rank} dimensions")
             Q_Nx, Q_Ny = Q_Nx // binfactor, Q_Ny // binfactor
@@ -106,6 +113,24 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
 
     dc.metadata = md
     return dc
+
+def _process_NCEM_TitanX_Tags(dmFile, dc=None):
+    """
+    Check the metadata in the DM File for certain tags which are added by the NCEM TitanX,
+    and reshape the 3D datacube into 4D using these tags. If no datacube is passed, 
+    return R_Nx and R_Ny
+    """
+    scanx = [v for k,v in dmFile.allTags.items() if "4D STEM Tags.Scan shape X" in k]
+    scany = [v for k,v in dmFile.allTags.items() if "4D STEM Tags.Scan shape Y" in k]
+    if len(scanx) == 1 and len(scany) == 1:
+        # TitanX tags found!
+        R_Nx = int(scanx[0])
+        R_Ny = int(scany[0])
+
+        if dc is not None:
+            dc.set_scan_shape(R_Nx,R_Ny)
+        else:
+            return R_Nx, R_Ny
 
 
 def get_metadata_from_dmFile(fp):


### PR DESCRIPTION
The NCEM TitanX, for historical reasons, saves its 4D datasets as a 3D array. Luckily, it writes a custom set of metadata tags into the DM file that indicate the proper 4D shape of the data. This update checks for the existence of those tags and reshapes the data accordingly if they are present. This fixes a bug where bin-on-load failed for Titan data because of the shape mismatch. 

I don't have a non-square dataset easily on hand, so I'd appreciate if someone has one on hand so we can test that there is not an x/y flip in the conventions. 