### PR TITLE
CUDA-accelerated multicorr

### DIFF
--- a/py4DSTEM/io/nonnative/read_dm.py
+++ b/py4DSTEM/io/nonnative/read_dm.py
@@ -51,6 +51,7 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
                     dataSet = dmFile.getDataset(i)
                 i += 1
             dc = DataCube(data=dataSet["data"])
+            _process_NCEM_TitanX_Tags(dmFile, dc)
     elif (mem, binfactor) == ("MEMMAP", 1):
         with dm.fileDM(fp, on_memory=False) as dmFile:
             # loop through the datasets until a >2D one is found:
@@ -62,6 +63,7 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
                     valid_data = True
                 i += 1
             dc = DataCube(data=memmap)
+            _process_NCEM_TitanX_Tags(dmFile, dc)
     elif (mem) == ("RAM"):
         with dm.fileDM(fp, on_memory=True) as dmFile:
             # loop through the datasets until a >2D one is found:
@@ -81,8 +83,13 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
             if rank==4:
                 R_Nx, R_Ny, Q_Nx, Q_Ny = shape
             elif rank==3:
-                R_Nx, Q_Nx, Q_Ny = shape
-                R_Ny = 1
+                titanTags = _process_NCEM_TitanX_Tags(dmFile)
+                if titanTags is not None:
+                    R_Nx, R_Ny = titanTags
+                    Q_Nx, Q_Ny = shape[1:]
+                else:
+                    R_Nx, Q_Nx, Q_Ny = shape
+                    R_Ny = 1
             else:
                 raise Exception(f"Data should be 4-dimensional; found {rank} dimensions")
             Q_Nx, Q_Ny = Q_Nx // binfactor, Q_Ny // binfactor
@@ -106,6 +113,24 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
 
     dc.metadata = md
     return dc
+
+def _process_NCEM_TitanX_Tags(dmFile, dc=None):
+    """
+    Check the metadata in the DM File for certain tags which are added by the NCEM TitanX,
+    and reshape the 3D datacube into 4D using these tags. If no datacube is passed, 
+    return R_Nx and R_Ny
+    """
+    scanx = [v for k,v in dmFile.allTags.items() if "4D STEM Tags.Scan shape X" in k]
+    scany = [v for k,v in dmFile.allTags.items() if "4D STEM Tags.Scan shape Y" in k]
+    if len(scanx) == 1 and len(scany) == 1:
+        # TitanX tags found!
+        R_Nx = int(scanx[0])
+        R_Ny = int(scany[0])
+
+        if dc is not None:
+            dc.set_scan_shape(R_Nx,R_Ny)
+        else:
+            return R_Nx, R_Ny
 
 
 def get_metadata_from_dmFile(fp):

--- a/py4DSTEM/io/nonnative/read_dm.py
+++ b/py4DSTEM/io/nonnative/read_dm.py
@@ -52,6 +52,7 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
                 i += 1
             dc = DataCube(data=dataSet["data"])
             _process_NCEM_TitanX_Tags(dmFile, dc)
+            
     elif (mem, binfactor) == ("MEMMAP", 1):
         with dm.fileDM(fp, on_memory=False) as dmFile:
             # loop through the datasets until a >2D one is found:
@@ -64,6 +65,7 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
                 i += 1
             dc = DataCube(data=memmap)
             _process_NCEM_TitanX_Tags(dmFile, dc)
+            
     elif (mem) == ("RAM"):
         with dm.fileDM(fp, on_memory=True) as dmFile:
             # loop through the datasets until a >2D one is found:
@@ -117,18 +119,19 @@ def read_dm(fp, mem="RAM", binfactor=1, metadata=False, **kwargs):
 def _process_NCEM_TitanX_Tags(dmFile, dc=None):
     """
     Check the metadata in the DM File for certain tags which are added by the NCEM TitanX,
-    and reshape the 3D datacube into 4D using these tags. If no datacube is passed, 
-    return R_Nx and R_Ny
+    and reshape the 3D datacube into 4D using these tags. Also fixes the two-pixel roll
+    issue present in TitanX data. If no datacube is passed, return R_Nx and R_Ny
     """
     scanx = [v for k,v in dmFile.allTags.items() if "4D STEM Tags.Scan shape X" in k]
     scany = [v for k,v in dmFile.allTags.items() if "4D STEM Tags.Scan shape Y" in k]
     if len(scanx) == 1 and len(scany) == 1:
         # TitanX tags found!
-        R_Nx = int(scanx[0])
-        R_Ny = int(scany[0])
+        R_Nx = int(scany[0]) # need to flip x/y
+        R_Ny = int(scanx[0])
 
         if dc is not None:
             dc.set_scan_shape(R_Nx,R_Ny)
+            dc.data = np.roll(dc.data,shift=-2,axis=1) # fix TitanX two-pixel roll issue
         else:
             return R_Nx, R_Ny
 

--- a/py4DSTEM/process/diskdetection/diskdetection.py
+++ b/py4DSTEM/process/diskdetection/diskdetection.py
@@ -493,6 +493,8 @@ def find_Bragg_disks(datacube, probe,
         (PointListArray): the Bragg peak positions and correlation intensities
     """
 
+    assert subpixel in [ 'none', 'poly', 'multicorr' ], "Unrecognized subpixel option {}, subpixel must be 'none', 'poly', or 'multicorr'".format(subpixel)
+
     def _parse_distributed(distributed):
         import os
 

--- a/py4DSTEM/process/diskdetection/diskdetection.py
+++ b/py4DSTEM/process/diskdetection/diskdetection.py
@@ -433,7 +433,8 @@ def find_Bragg_disks(datacube, probe,
                      _qt_progress_bar = None,
                      distributed = None,
                      CUDA = False,
-                     CUDA_batched = True,):
+                     CUDA_batched = True,
+                     CUDA_clear_mempool = True):
     """
     Finds the Bragg disks in all diffraction patterns of datacube by cross, hybrid, or
     phase correlation with probe.
@@ -488,6 +489,9 @@ def find_Bragg_disks(datacube, probe,
         CUDA (bool): If True, import cupy and use an NVIDIA GPU to perform disk detection
         CUDA_batched (bool): If True, and CUDA is selected, the FFT and IFFT steps of
             disk detection are performed in batches to better utilize GPU resources. 
+        CUDA_clear_mempool (bool): Free up memory blocks allocated by cupy once
+            disk detection is complete. May cause interference with the memory of 
+            other cupy-accelerated code used in the same Python instance.
 
     Returns:
         (PointListArray): the Bragg peak positions and correlation intensities
@@ -571,7 +575,7 @@ def find_Bragg_disks(datacube, probe,
                 _qt_progress_bar=_qt_progress_bar)
         else:
             from .diskdetection_cuda import find_Bragg_disks_CUDA
-            return find_Bragg_disks_CUDA(
+            braggdisks = find_Bragg_disks_CUDA(
                 datacube,
                 probe,
                 corrPower=corrPower,
@@ -587,7 +591,13 @@ def find_Bragg_disks(datacube, probe,
                 name=name,
                 filter_function=filter_function,
                 _qt_progress_bar=_qt_progress_bar,
-                batching=CUDA_batched)
+                batching=CUDA_batched,)
+
+            if CUDA_clear_mempool:
+                import cupy as cp
+                cp.get_default_memory_pool().free_all_blocks()
+
+            return braggdisks
 
     elif isinstance(distributed, dict):
         connect, data_file, cluster_path = _parse_distributed(distributed)

--- a/py4DSTEM/process/diskdetection/diskdetection_cuda.py
+++ b/py4DSTEM/process/diskdetection/diskdetection_cuda.py
@@ -133,7 +133,7 @@ def find_Bragg_disks_CUDA(
         # compute the batch size based on available VRAM:
         max_num_bytes = cp.cuda.Device().mem_info[0]
         # use a fudge factor to leave room for the fourier transformed data
-        # I have set this at 10, which results in underutilization of 
+        # I have set this at 15, which results in underutilization of 
         # VRAM, because this yielded better performance in my testing
         batch_size = max_num_bytes // (bytes_per_pattern * 15)
         num_batches = datacube.R_N // batch_size + 1

--- a/py4DSTEM/process/diskdetection/kernels.py
+++ b/py4DSTEM/process/diskdetection/kernels.py
@@ -29,8 +29,8 @@ maximal_pts_float32 = r'''
 extern "C" __global__
 void maximal_pts(const float *ar, bool *out, const double minAbsoluteIntensity, const long long sizex, const long long sizey, const long long N){
     int tid = blockDim.x * blockIdx.x + threadIdx.x;
-    int x = tid / sizex;
-    int y = tid % sizex;
+    int x = tid / sizey;
+    int y = tid % sizey;
     bool res = false;
     if (tid < N && x>0 && x<(sizex-1) && y>0 && y<(sizey-1)) {
         float val = ar[tid];
@@ -54,8 +54,8 @@ maximal_pts_float64 = r'''
 extern "C" __global__
 void maximal_pts(const double *ar, bool *out, const double minAbsoluteIntensity, const long long sizex, const long long sizey, const long long N){
     int tid = blockDim.x * blockIdx.x + threadIdx.x;
-    int x = tid / sizex;
-    int y = tid % sizex;
+    int x = tid / sizey;
+    int y = tid % sizey;
     bool res = false;
     if (tid < N && x>0 && x<(sizex-1) && y>0 && y<(sizey-1)) {
         double val = ar[tid];

--- a/py4DSTEM/process/diskdetection/kernels.py
+++ b/py4DSTEM/process/diskdetection/kernels.py
@@ -4,6 +4,15 @@ __all__ = ['kernels']
 
 kernels = {}
 
+############################# multicorr kernels #################################
+
+import os
+with open(os.path.join(os.path.dirname(__file__), "multicorr_row_kernel.cu"), 'r') as f:
+    kernels['multicorr_row_kernel'] = cp.RawKernel(f.read(), 'multicorr_row_kernel')
+
+with open(os.path.join(os.path.dirname(__file__), "multicorr_col_kernel.cu"), 'r') as f:
+    kernels['multicorr_col_kernel'] = cp.RawKernel(f.read(), 'multicorr_col_kernel')
+
 
 ############################# get_maximal_points ################################
 

--- a/py4DSTEM/process/diskdetection/kernels.py
+++ b/py4DSTEM/process/diskdetection/kernels.py
@@ -29,8 +29,8 @@ maximal_pts_float32 = r'''
 extern "C" __global__
 void maximal_pts(const float *ar, bool *out, const double minAbsoluteIntensity, const long long sizex, const long long sizey, const long long N){
     int tid = blockDim.x * blockIdx.x + threadIdx.x;
-    int x = tid % sizex;
-    int y = tid / sizey; // Floor divide
+    int x = tid / sizex;
+    int y = tid % sizex;
     bool res = false;
     if (tid < N && x>0 && x<(sizex-1) && y>0 && y<(sizey-1)) {
         float val = ar[tid];
@@ -54,8 +54,8 @@ maximal_pts_float64 = r'''
 extern "C" __global__
 void maximal_pts(const double *ar, bool *out, const double minAbsoluteIntensity, const long long sizex, const long long sizey, const long long N){
     int tid = blockDim.x * blockIdx.x + threadIdx.x;
-    int x = tid % sizex;
-    int y = tid / sizey; // Floor divide
+    int x = tid / sizex;
+    int y = tid % sizex;
     bool res = false;
     if (tid < N && x>0 && x<(sizex-1) && y>0 && y<(sizey-1)) {
         double val = ar[tid];

--- a/py4DSTEM/process/diskdetection/multicorr_col_kernel.cu
+++ b/py4DSTEM/process/diskdetection/multicorr_col_kernel.cu
@@ -1,0 +1,61 @@
+#include <cupy/complex.cuh>
+#define PI 3.14159265359
+extern "C" __global__
+void multicorr_col_kernel(
+	complex<float> *ar,
+	const float *xyShifts,
+	const long long N_pts,
+	const long long image_size_x,
+	const long long image_size_y,
+	const long long upsample_factor) {
+	/*
+	Fill in the entries of the multicorr row kernel.
+	Inputs (C++ type/Python type):
+		ar (complex<float>* / cp.complex64):	Array of size N_pts x image_size[1] x kernel_size
+				to hold the row kernels
+		xyShifts (const float* / cp.float32): (N_pts x 2) array of center points to build kernels for
+		N_pts (const long long/int) number of center points we are
+				building kernels for
+		image_size_x (const long long/int): x size of the correlation image
+		image_size_y (const long long/int): y size of correlation image
+		upsample_factor (const long long/int): note, kernel_width = ceil(1.5*upsample_factor)
+	*/
+	int kernel_size = ceil(1.5 * upsample_factor);
+
+	int tid = blockDim.x * blockIdx.x + threadIdx.x;
+
+	// Using strides to compute indices:
+	int stride_0 = image_size_y * kernel_size; // Stride along 0-th dimension of ar
+	int stride_1 = kernel_size; // Stride along 1-th dimension of ar
+
+	// Which kernel in the stack (first index of ar)
+	int kernel_idx = tid / stride_0;
+	// Which row in the kernel (second index of ar)
+	int row_idx = (tid % stride_0) / stride_1;
+	// Which column in the kernel (last index of ar)
+	int col_idx = (tid % stride_0) % stride_1;
+
+	complex<float> prefactor = complex<float>(0,-2.0 * PI) / float(image_size_y * upsample_factor);
+
+	// Now do the actual calculation
+	if (tid < N_pts * image_size_y * kernel_size) {
+		// np.fft.ifftshift(np.arange(imageSize[1])) - np.floor(imageSize[1]/2)
+		// modresult is necessary to get the Pythonic behavior of mod of negative numbers
+		int modresult = int(row_idx - ceil((float)image_size_y / 2.)) % image_size_y;
+		modresult = modresult < 0 ? modresult + image_size_y : modresult;
+		float columnEntry = float(modresult) - floor((float)image_size_y/2.) ; 
+
+
+		// np.arange(numColumns) - xyShift[idx,0]
+		float rowEntry = (float)col_idx - xyShifts[kernel_idx*2 + 1];
+
+		ar[tid] = exp(prefactor * columnEntry * rowEntry);
+
+		// Use these for testing the indexing:
+		// ar[tid] = complex<float>(0,(float)tid);
+		// ar[tid] = complex<float>(0,(float)kernel_idx);
+		// ar[tid] = complex<float>(0,(float)row_idx);
+		// ar[tid] = complex<float>(0,(float)col_idx);
+	}
+
+}

--- a/py4DSTEM/process/diskdetection/multicorr_row_kernel.cu
+++ b/py4DSTEM/process/diskdetection/multicorr_row_kernel.cu
@@ -1,0 +1,60 @@
+#include <cupy/complex.cuh>
+#define PI 3.14159265359
+extern "C" __global__
+void multicorr_row_kernel(
+	complex<float> *ar,
+	const float *xyShifts,
+	const long long N_pts,
+	const long long image_size_x,
+	const long long image_size_y,
+	const long long upsample_factor) {
+	/*
+	Fill in the entries of the multicorr row kernel.
+	Inputs (C++ type/Python type):
+		ar (complex<float>* / cp.complex64):	Array of size N_pts x kernel_size x image_size[0]
+				to hold the row kernels
+		xyShifts (const float* / cp.float32): (N_pts x 2) array of center points to build kernels for
+		N_pts (const long long/int) number of center points we are
+				building kernels for
+		image_size_x (const long long/int): x size of the correlation image
+		image_size_y (const long long/int): y size of correlation image
+		upsample_factor (const long long/int): note, kernel_width = ceil(1.5*upsample_factor)
+	*/
+	int kernel_size = ceil(1.5 * upsample_factor);
+
+	int tid = blockDim.x * blockIdx.x + threadIdx.x;
+	
+	// Using strides to compute indices:
+	int stride_0 = image_size_x * kernel_size; // Stride along 0-th dimension of ar
+	int stride_1 = image_size_x; // Stride along 1-th dimension of ar
+
+	// Which kernel in the stack (first index of ar)
+	int kernel_idx = tid / stride_0;
+	// Which row in the kernel (second index of ar)
+	int row_idx = (tid % stride_0) / stride_1;
+	// Which column in the kernel (last index of ar)
+	int col_idx = (tid % stride_0) % stride_1;
+
+	complex<float> prefactor = complex<float>(0,-2.0 * PI) / float(image_size_x * upsample_factor);
+
+	// Now do the actual calculation
+	if (tid < N_pts * image_size_x * kernel_size) {
+		// np.arange(numColumns) - xyShift[idx,0]
+		float columnEntry = (float)row_idx - xyShifts[kernel_idx*2];
+
+		// np.fft.ifftshift(np.arange(imageSize[0])) - np.floor(imageSize[0]/2)
+		// modresult is necessary to get the Pythonic behavior of mod of negative numbers
+		int modresult = int(col_idx - ceil((float)image_size_x / 2.)) % image_size_x;
+		modresult = modresult < 0 ? modresult + image_size_x : modresult;
+		float rowEntry = float(modresult) - floor((float)image_size_x/2.) ; 
+
+		ar[tid] = exp(prefactor * columnEntry * rowEntry);
+
+		// Use these for testing the indexing:
+		//ar[tid] = complex<float>(0,(float)tid);
+		//ar[tid] = complex<float>(0,(float)kernel_idx);
+		//ar[tid] = complex<float>(0,(float)row_idx);
+		//ar[tid] = complex<float>(0,(float)col_idx);
+	}
+
+}

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setup(
         'console_scripts': ['py4DSTEM=py4DSTEM.gui.runGUI:launch']
     },
     package_data={
-        'py4DSTEM':['process/utils/scattering_factors.txt']
+        'py4DSTEM':['process/utils/scattering_factors.txt',
+                    'process/diskdetection/multicorr_row_kernel.cu',
+                    'process/diskdetection/multicorr_col_kernel.cu']
     },
 )


### PR DESCRIPTION
This substantially reworks how multicorr is implemented in the CUDA-accelerated Bragg disk detection routine. The matrix-multiply DFT arrays are now generated by custom CUDA kernels, and the process is vectorized across all of the disk positions found in a single diffraction pattern. This gives an approximately 4x speedup over the previous implementation when using `unsample_factor=16`, and is now about half as fast as `upsample='poly'` at the same upsample factor. This PR also includes some bugfixes to the batched disk detection, including fixing an indexing error in the maximal points routine that was causing out-of-bounds memory access on the device for non-square diffraction patterns. 