### PR TITLE
adds new io defaults

### DIFF
--- a/py4DSTEM/io/google_drive_downloader.py
+++ b/py4DSTEM/io/google_drive_downloader.py
@@ -9,19 +9,33 @@ import os
 # single files
 sample_file_ids = {
     'FCU-Net' : '1-KX0saEYfhZ9IJAOwabH38PCVtfXidJi',
-    'sample_diffraction_pattern':'1ymYMnuDC0KV6dqduxe2O1qafgSd0jjnU'
+    'sample_diffraction_pattern':'1ymYMnuDC0KV6dqduxe2O1qafgSd0jjnU',
+    'Au_sim':'1PmbCYosA1eYydWmmZebvf6uon9k_5g_S',
+    'carbon_nanotube':'1bHv3u61Cr-y_GkdWHrJGh1lw2VKmt3UM',
+    'Si_SiGe_exp':'1fXNYSGpe6w6E9RBA-Ai_owZwoj3w8PNC',
+    'Si_SiGe_probe':'141Tv0YF7c5a-MCrh3CkY_w4FgWtBih80',
+    'Si_SiGe_EELS_strain':'1klkecq8IuEOYB-bXchO7RqOcgCl4bmDJ',
+    'AuAgPd_wire':'1OQYW0H6VELsmnLTcwicP88vo2V5E3Oyt',
+    'AuAgPd_wire_probe':'17OduUKpxVBDumSK_VHtnc2XKkaFVN8kq',
+    'polycrystal_2D_WS2':'1AWB3-UTPiTR9dgrEkNFD7EJYsKnbEy0y',
+    'WS2cif':'13zBl6aFExtsz_sew-L0-_ALYJfcgHKjo',
+    'polymers':'1lK-TAMXN1MpWG0Q3_4vss_uEZgW2_Xh7',
 }
 
 # collections of files
 sample_collection_ids = {
-    'testdata' : (
-        ('file1', '1-KX0saEYfhZ9IJAOwabH38PCVtfXidJi'),
-        ('file2', '1ymYMnuDC0KV6dqduxe2O1qafgSd0jjnU')
+    'tutorials' : (
+        ('simulated_Au_single+polyXtal.h5', sample_file_ids['Au_sim']),
+        ('carbon_nanotube.h5', sample_file_ids['carbon_nanotube']),
+        ('Si_SiGe_exp.h5',sample_file_ids['Si_SiGe_exp']),
+        ('Si_SiGe_probe.h5',sample_file_ids['Si_SiGe_probe']),
+        ('Si_SiGe_EELS_strain.h5',sample_file_ids['Si_SiGe_EELS_strain']),
+        ('AuAgPd_wire.h5',sample_file_ids['AuAgPd_wire']),
+        ('AuAgPd_wire_probe.h5',sample_file_ids['AuAgPd_wire_probe']),
+        ('polycrystal_2D_WS2.h5',sample_file_ids['polycrystal_2D_WS2']),
+        ('WS2.cif',sample_file_ids['WS2cif']),
+        ('polymers.h5',sample_file_ids['polymers']),
     ),
-    'moretestdata' : (
-        ('file3','id'),
-        ('file4','id')
-    )
 }
 
 

--- a/py4DSTEM/io/read.py
+++ b/py4DSTEM/io/read.py
@@ -11,7 +11,7 @@ from py4DSTEM.io.utils import parse_filetype
 
 def read(
     filepath: Union[str,pathlib.Path],
-    root: Optional[str] = '4DSTEM',
+    root: Optional[str] = None,
     tree: Optional[Union[bool,str]] = True,
     **kwargs,
     ):
@@ -30,7 +30,11 @@ def read(
         root (str): the path to the root data group in the HDF5 file
             to read from. To examine an HDF5 file written by py4DSTEM
             in order to determine this path, call
-            `py4DSTEM.print_h5_tree(filepath)`.
+            `py4DSTEM.print_h5_tree(filepath)`. If left unspecified,
+            looks in the file and if it finds a single top-level
+            object, loads it. If it finds multiple top-level objects,
+            prints a warning and returns a list of root paths to the
+            top-level object found
         tree (bool or str): indicates what data should be loaded,
             relative to the root group specified above.  must be in
             (`True` or `False` or `noroot`).  If set to `False`, the

--- a/py4DSTEM/process/probe/kernel.py
+++ b/py4DSTEM/process/probe/kernel.py
@@ -90,7 +90,8 @@ def _make_function_dict():
 
 def get_probe_kernel(
     probe,
-    origin=None
+    origin=None,
+    bilinear=True
     ):
     """
     Creates a convolution kernel from an average probe, by normalizing, then
@@ -119,7 +120,7 @@ def get_probe_kernel(
     probe = probe/np.sum(probe)
 
     # Shift center to corners of array
-    probe_kernel = get_shifted_ar(probe, -xCoM, -yCoM)
+    probe_kernel = get_shifted_ar(probe, -xCoM, -yCoM, bilinear=bilinear)
 
     return probe_kernel
 
@@ -128,7 +129,7 @@ def get_probe_kernel_edge_gaussian(
         probe,
         sigma,
         origin=None,
-        bilinear=False,
+        bilinear=True,
         ):
     """
     Creates a convolution kernel from an average probe, subtracting a gaussian
@@ -143,7 +144,7 @@ def get_probe_kernel_edge_gaussian(
         origin (2-tuple or None): if None (default), finds the origin using
             get_probe_radius. Otherwise, should be a 2-tuple (x0,y0) specifying
             the origin position
-        bilinear (bool): By default probe is shifted via a Fourier transform. 
+        bilinear (bool): By default probe is shifted via a Fourier transform.
                          Setting this to true overrides it and uses bilinear shifting.
                          Not recommended!
 
@@ -182,7 +183,7 @@ def get_probe_kernel_edge_sigmoid(
     radii,
     origin=None,
     type='sine_squared',
-    bilinear=False,
+    bilinear=True,
     ):
     """
     Creates a convolution kernel from an average probe, subtracting an annular
@@ -247,24 +248,28 @@ def _get_probe_kernel_edge_sigmoid_sine_squared(
     probe,
     radii,
     origin=None,
+    **kwargs,
     ):
     return get_probe_kernel_edge_sigmoid(
         probe,
         radii,
         origin = origin,
-        type='sine_squared'
+        type='sine_squared',
+        **kwargs,
     )
 
 def _get_probe_kernel_edge_sigmoid_logistic(
     probe,
     radii,
     origin=None,
+    **kwargs,
     ):
     return get_probe_kernel_edge_sigmoid(
         probe,
         radii,
         origin = origin,
-        type='logistic'
+        type='logistic',
+        **kwargs
     )
 
 

--- a/py4DSTEM/process/probe/kernel.py
+++ b/py4DSTEM/process/probe/kernel.py
@@ -103,6 +103,9 @@ def get_probe_kernel(
         origin (2-tuple or None): if None (default), finds the origin using
             get_probe_radius. Otherwise, should be a 2-tuple (x0,y0) specifying
             the origin position
+        bilinear (bool): By default probe is shifted via a Fourier transform. 
+                 Setting this to True overrides it and uses bilinear shifting.
+                 Not recommended!
 
     Returns:
         (ndarray): the convolution kernel corresponding to the probe, in real
@@ -145,7 +148,7 @@ def get_probe_kernel_edge_gaussian(
             get_probe_radius. Otherwise, should be a 2-tuple (x0,y0) specifying
             the origin position
         bilinear (bool): By default probe is shifted via a Fourier transform.
-                         Setting this to true overrides it and uses bilinear shifting.
+                         Setting this to True overrides it and uses bilinear shifting.
                          Not recommended!
 
     Returns:
@@ -199,7 +202,7 @@ def get_probe_kernel_edge_sigmoid(
             the origin position
         type (string): must be 'logistic' or 'sine_squared'
         bilinear (bool): By default probe is shifted via a Fourier transform. 
-                 Setting this to true overrides it and uses bilinear shifting.
+                 Setting this to True overrides it and uses bilinear shifting.
                  Not recommended!
 
     Returns:

--- a/py4DSTEM/test/io/test_io_defaults.py
+++ b/py4DSTEM/test/io/test_io_defaults.py
@@ -1,0 +1,184 @@
+# testing the default read/write behavior
+# in order to support auto-read/write without specifying paths within the h5 file
+# for simple cases with a single object
+
+# Tests 4 use cases:
+
+# (1) save one object, with nothing it its tree. then load it.
+# (2) save one object, with stuff in its tree. then load it.
+# (3) load from a file with one top-level object and some tree underneath it,
+#     but load something other than the top level object
+# (4) load from a file with multiple top level objects.
+
+
+import py4DSTEM
+import numpy as np
+import os
+
+
+### Prepare data
+
+## Load a datacube and populate its tree with some objects
+
+# Set filepath to a datacube
+filepath_dm = "/media/AuxDriveB/Data/HadasSternlicht/conductive_polymers/500C/dataset_123_aluminumStandard/dataset_123.dm4"
+
+# Load a datacube from a dm file
+datacube = py4DSTEM.io.import_file(filepath_dm)
+datacube = py4DSTEM.io.datastructure.DataCube(
+    data=datacube.data[0:15,0:20,:,:])
+
+# Virtual diffraction
+dp_max = datacube.get_dp_max()
+dp_mean = datacube.get_dp_mean()
+dp_median = datacube.get_dp_median()
+
+# Virtual imaging
+geometry_BF = (
+    (432,432),
+    30
+)
+geometry_ADF = (
+    (432,432),
+    (80,300)
+)
+im_BF = datacube.get_virtual_image(
+    mode = 'circle',
+    geometry = geometry_BF,
+    name = 'vBF'
+)
+im_ADF = datacube.get_virtual_image(
+    mode = 'annulus',
+    geometry = geometry_ADF,
+    name = 'vADF'
+)
+
+
+## Prepare other objects without trees: a second datacube, and an array
+datacube2 = py4DSTEM.io.DataCube(
+    data = np.copy(datacube.data),
+    name = 'datacube2'
+)
+
+array = py4DSTEM.io.Array(
+    data = np.arange(6*7*8).reshape(6,7,8),
+    name = 'some_array'
+)
+
+
+
+### Test io
+
+filepath1 = "/home/ben/Desktop/test1.h5"
+filepath2 = "/home/ben/Desktop/test2.h5"
+filepath3 = "/home/ben/Desktop/test3.h5"
+filepath4 = "/home/ben/Desktop/test4.h5"
+for fp in (filepath1,filepath2,filepath3,filepath4):
+    if os.path.exists(fp): os.remove(fp)
+
+
+# Use case 1:
+
+print('\n*** Use Case #1 ***\n')
+
+# save a DataCube with nothing in its Tree
+py4DSTEM.io.save(
+    filepath1,
+    datacube2,
+)
+# check contents
+py4DSTEM.io.print_h5_tree(filepath1)
+# read the object, without specifying a path inside the .h5
+d = py4DSTEM.io.read(
+    filepath1,
+)
+# check the output
+print(d)
+print(d.tree)
+
+
+
+
+# Use case 2:
+
+print('\n*** Use Case #2 ***\n')
+
+# save a DataCube with data in its Tree
+py4DSTEM.io.save(
+    filepath2,
+    datacube,
+)
+# check contents
+py4DSTEM.io.print_h5_tree(filepath2)
+# read the object, without specifying a path inside the .h5
+d = py4DSTEM.io.read(
+    filepath2,
+)
+# check the output
+print(d)
+print(d.tree)
+
+
+
+
+
+# Use case 3:
+
+print('\n*** Use Case #3 ***\n')
+
+# save a DataCube with data in its Tree
+py4DSTEM.io.save(
+    filepath3,
+    datacube,
+)
+# check contents
+py4DSTEM.io.print_h5_tree(filepath3)
+# read from a specifyied path inside the .h5
+d = py4DSTEM.io.read(
+    filepath3,
+    root = '4DSTEM/datacube/vBF'
+)
+# check the output
+print(d)
+print(d.tree)
+
+
+
+
+
+
+# Use case 4:
+
+print('\n*** Use Case #4 ***\n')
+
+# save a DataCube with multipl top level objects
+py4DSTEM.io.save(
+    filepath4,
+    datacube,
+)
+py4DSTEM.io.save(
+    filepath4,
+    datacube2,
+    mode = 'a'
+)
+py4DSTEM.io.save(
+    filepath4,
+    array,
+    mode = 'a'
+)
+# check contents
+py4DSTEM.io.print_h5_tree(filepath4)
+# read from the file
+d = py4DSTEM.io.read(
+    filepath4,
+    root = '4DSTEM/some_array/'
+)
+# check the output
+print(d)
+print(d.tree)
+
+
+
+
+
+


### PR DESCRIPTION
Edits the default behavior of the `read` function such that if `read(filepath)` is called with no additional parameters specified:

- if the file contains only one block of data, finds and returns it
- if the file contains multiple top level groups (e.g. '4DSTEM_experiment' and '4DSTEM_simulation'), raises a warning and returns those two group names
- if the file contains a single top level group (e.g. the default, '4DSTEM') but this group contains multiple objets in its own top level, raises a warning and returns a list of valid h5 paths to those objects (e.g. ['4DSTEM/datacube', '4DSTEM/virtual_image'])

All other behavior is unchanged, so `Tree=True` is still default, meaning if a single block of data which contains a large tree of data underneath it, all that data will be saved/loaded by default using `save(path,data)`/`read(path)`