### PR TITLE
Bugfix for process.dpc.get_CoM when mask=None

### DIFF
--- a/py4DSTEM/process/dpc/dpc.py
+++ b/py4DSTEM/process/dpc/dpc.py
@@ -15,7 +15,7 @@ def get_CoM_images(datacube, mask=None, normalize=True):
 
     Args:
         datacube (DataCube): the 4D-STEM data
-        mask (2D array): optionally, calculate the CoM only in the areas where mask==True
+        mask (2D array): optionally, calculate the CoM only in the areas where mask==True. The function will cast the input array to a bool dtype
         normalize (bool): if true, subtract off the mean of the CoM images
 
     Returns:
@@ -26,9 +26,14 @@ def get_CoM_images(datacube, mask=None, normalize=True):
 
     # Coordinates
     qy,qx = np.meshgrid(np.arange(datacube.Q_Ny),np.arange(datacube.Q_Nx))
-    if mask is not None:
-        qx *= mask
-        qy *= mask
+    if mask is None:
+        mask = np.ones_like(qx).astype(bool)
+    else:
+        assert qy.shape == mask.shape, f"The mask shape {mask.shape} must equal the diffraction pattern shape {qy.shape}."
+        mask = mask.astype(bool)
+
+    qx *= mask
+    qy *= mask
 
     # Get CoM
     CoMx = np.zeros((datacube.R_Nx,datacube.R_Ny))


### PR DESCRIPTION
Prior to this fix, the following message would appear when `mask=None`:

```python
File ~/Documents/Research/code/py4DSTEM/py4DSTEM/process/dpc/dpc.py:40, in get_CoM_images(datacube, mask, normalize)
     38 for Ry in range(datacube.R_Ny):
     39     DP = datacube.data[Rx,Ry,:,:]
---> 40     mass[Rx,Ry] = np.sum(DP*mask)
     41     CoMx[Rx,Ry] = np.sum(qx*DP) / mass[Rx,Ry]
     42     CoMy[Rx,Ry] = np.sum(qy*DP) / mass[Rx,Ry]

TypeError: unsupported operand type(s) for *: 'float' and 'NoneType'
```

There is some code duplication with `process.utils.get_CoM` but I think that is ok for now, as it probably is faster to not be creating `qx` and `qy` arrays every time in the inner loop. `utils.get_CoM` could be changed to accept optional arguments `qx`, `qy` and `mask`, and then the inner loop could just be a call to it, which would probably be best, but not really a bugfix.