### PR TITLE
Show fix to compute clipvals after masking

### DIFF
--- a/py4DSTEM/process/utils/get_maxima_2D.py
+++ b/py4DSTEM/process/utils/get_maxima_2D.py
@@ -78,7 +78,7 @@ def get_maxima_2D(
     maxima = np.sort(maxima, order='intensity')[::-1]
 
     if len(maxima) == 0:
-            return maxima
+        return maxima
 
 
     # filter

--- a/py4DSTEM/visualize/show.py
+++ b/py4DSTEM/visualize/show.py
@@ -354,8 +354,8 @@ def show(
     elif isinstance(ar,np.ma.masked_array):
         pass
     else:
-        mask = np.ones_like(ar,dtype=bool)
-        ar = np.ma.array(data=ar,mask=mask==False)
+        mask = np.zeros_like(ar,dtype=bool)
+        ar = np.ma.array(data=ar,mask=mask)
 
     # Perform any scaling
     if scaling == 'none':
@@ -382,7 +382,9 @@ def show(
     else:
         raise Exception
 
-    _ar = np.ma.array(data=_ar.data,mask=~_mask)
+    # Create the masked array applying the user mask (this is done before the 
+    # vmin and vmax are determined so the mask affects those)
+    _ar = np.ma.array(data=_ar.data,mask=np.logical_or(~_mask, ar.mask))
 
     # Set the clipvalues
     if clipvals == 'minmax':
@@ -411,9 +413,6 @@ def show(
         assert(isinstance(fig,Figure))
         assert(isinstance(ax,Axes))
 
-    # Create the masked array applying the user mask (this is done after the 
-    # vmin and vmax are determined so the mask doesn't affect those)
-    _ar = np.ma.array(data=_ar.data,mask=np.logical_or(ar.mask,~_mask))
 
     # Create colormap with mask_color for bad values
     cm = copy(plt.cm.get_cmap(cmap))

--- a/py4DSTEM/visualize/show.py
+++ b/py4DSTEM/visualize/show.py
@@ -914,7 +914,7 @@ def show_circles(ar,center,R,color='r',fill=True,alpha=0.3,linewidth=2,returnfig
     else:
         return fig,ax
 
-def show_ellipses(ar,center,a,e,theta,color='r',fill=True,alpha=0.3,linewidth=2,
+def show_ellipses(ar,center,a,b,theta,color='r',fill=True,alpha=0.3,linewidth=2,
                                                         returnfig=False,**kwargs):
     """
     Visualization function which plots a 2D array with one or more overlayed ellipses.
@@ -943,7 +943,7 @@ def show_ellipses(ar,center,a,e,theta,color='r',fill=True,alpha=0.3,linewidth=2,
         further edited.
     """
     fig,ax = show(ar,returnfig=True,**kwargs)
-    d = {'center':center,'a':a,'e':e,'theta':theta,'color':color,'fill':fill,
+    d = {'center':center,'a':a,'b':b,'theta':theta,'color':color,'fill':fill,
          'alpha':alpha,'linewidth':linewidth}
     add_ellipses(ax,d)
 

--- a/py4DSTEM/visualize/vis_special.py
+++ b/py4DSTEM/visualize/vis_special.py
@@ -432,8 +432,8 @@ def show_strain(strainmap,
     # Add black background
     if bkgrd:
         mask = np.ma.masked_where(
-            strainmap.get_slice('mask').astype(bool),
-            np.zeros_like(strainmap.get_slice('mask')))
+            strainmap.get_slice('mask').data.astype(bool),
+            np.zeros_like(strainmap.get_slice('mask').data))
         ax11.matshow(mask,cmap='gray')
         ax12.matshow(mask,cmap='gray')
         ax21.matshow(mask,cmap='gray')

--- a/sample_code/visualize/show.ipynb
+++ b/sample_code/visualize/show.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "### Versioning\n",
     "\n",
-    "Last updated on 2021-04-23 with py4DSTEM v.0.12.0."
+    "Last updated on 2022-09-20 with py4DSTEM v.0.13.6."
    ]
   },
   {
@@ -23,7 +23,10 @@
    "source": [
     "import py4DSTEM.visualize as vis\n",
     "import matplotlib.pyplot as plt\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import py4DSTEM\n",
+    "\n",
+    "print(py4DSTEM.__version__)"
    ]
   },
   {
@@ -129,7 +132,8 @@
     "# Setting `returnfig=True` returns the figure and axis objects\n",
     "from py4DSTEM.process.utils import get_maxima_2D\n",
     "fig,ax = vis.show(im,figsize=(6,3),returnfig=True)\n",
-    "xmaxima,ymaxima,_ = get_maxima_2D(im)\n",
+    "maxima = get_maxima_2D(im, maxNumPeaks=18)\n",
+    "xmaxima, ymaxima = maxima['x'], maxima['y']\n",
     "ax.scatter(ymaxima,xmaxima,color='blue')\n",
     "plt.show()"
    ]
@@ -141,7 +145,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Alternatively, setting `figax=(fig,ax)` tells show to plot inside some existing matplotlib Axes instance\n",
+    "# Alternatively, setting `figax=(fig,ax)` tells \n",
+    "# show to plot inside some existing matplotlib Axes instance\n",
     "fig,(ax1,ax2) = plt.subplots(2,1,figsize=(6,6))\n",
     "vis.show(im,figax=(fig,ax1))\n",
     "vis.show(im,figax=(fig,ax2),hist=True,n_bins=32)\n",
@@ -270,8 +275,8 @@
    "source": [
     "ann_center = (28,68)\n",
     "ann_Ri,ann_Ro = 16,24\n",
-    "vis.show_annuli(im,ann_center,ann_Ri,ann_Ro)\n",
-    "vis.show_annuli(im,center=[(28,68),(92,160)],Ri=[16,12],Ro=[24,36],color=['r',(0,1,1,1)])"
+    "vis.show_annuli(im,ann_center,(ann_Ri,ann_Ro))\n",
+    "vis.show_annuli(im,center=[(28,68),(92,160)],radii=[(16,24), (12,36)],color=['r',(0,1,1,1)])"
    ]
   },
   {
@@ -282,7 +287,7 @@
    "outputs": [],
    "source": [
     "vis.show_ellipses(im,center=[(40,48),(80,176)],alpha=1,\n",
-    "                                 a=[32,32],e=0.75,theta=[0,np.pi/4.],color='pink',fill=False)"
+    "                                 a=[32,32],b=[20,30],theta=[0,np.pi/4.],color='pink',fill=False)"
    ]
   },
   {
@@ -305,9 +310,9 @@
     "                 'color':list(colors_circle),\n",
     "                 'fill':True},\n",
     "         annulus={'center':[(28,68),(92,160)],'fill':True,'alpha':[0.9,0.3],\n",
-    "                  'Ri':[16,12],'Ro':[24,36],'color':['r',(0,1,1,1)]},\n",
+    "                  'radii':[(16,24), (12,36)],'color':['r',(0,1,1,1)]},\n",
     "         ellipse={'center':[(40,48),(80,176)],\n",
-    "                  'a':[32,32],'e':0.75,'theta':[0,np.pi/4.],'fill':False,'linewidth':2,\n",
+    "                  'a':[32,32],'b':[15,30],'theta':[0,np.pi/4.],'fill':False,'linewidth':2,\n",
     "                  'color':'pink','ls':'-','alpha':1})"
    ]
   },
@@ -357,7 +362,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.8.13 ('py4dstem')",
    "language": "python",
    "name": "python3"
   },
@@ -371,7 +376,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "16cf4ea88f04de76dbac5635bddffd882f42ba619604d4144e123631135907f5"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This changes the behavior of `show` to compute `clipvals` after creating a combined mask from the mask that is passed in, and the mask required by the scaling option chosen. 

Old behavior, when data is the `max_dp` from a stack:

<img width="472" alt="image" src="https://user-images.githubusercontent.com/9438848/191245838-608b1832-bc6d-4769-808b-1f56f94aac6e.png">

New behavior:

<img width="462" alt="image" src="https://user-images.githubusercontent.com/9438848/191245910-8851f3c2-e899-4a59-83a4-585148d7096c.png">

I think this makes a much more sensible default - masked areas shouldn't affect the `vmin` or `vmax` value when plotting. This way, if you pass in a mask, and mask off the central spot, its overwhelming intensity isn't used in the calculation. 

To test that the change didn't break anything, I ran through `show.ipynb` in the `sample_code` directory. In doing so, I updated it and `show.py` to be v0.13.6 compatible.  