### PR TITLE
Fixes show_ functions blocking figures from further plotting

### DIFF
--- a/py4DSTEM/visualize/show.py
+++ b/py4DSTEM/visualize/show.py
@@ -923,7 +923,6 @@ def show_rectangles(ar,lims=(0,1,0,1),color='r',fill=True,alpha=0.25,linewidth=2
     add_rectangles(ax,d)
 
     if not returnfig:
-        plt.show()
         return
     else:
         return fig,ax
@@ -956,7 +955,6 @@ def show_circles(ar,center,R,color='r',fill=True,alpha=0.3,linewidth=2,returnfig
     add_circles(ax,d)
 
     if not returnfig:
-        plt.show()
         return
     else:
         return fig,ax
@@ -995,7 +993,6 @@ def show_ellipses(ar,center,a,b,theta,color='r',fill=True,alpha=0.3,linewidth=2,
     add_ellipses(ax,d)
 
     if not returnfig:
-        plt.show()
         return
     else:
         return fig,ax
@@ -1030,7 +1027,6 @@ def show_annuli(ar,center,radii,color='r',fill=True,alpha=0.3,linewidth=2,return
     add_annuli(ax,d)
 
     if not returnfig:
-        plt.show()
         return
     else:
         return fig,ax
@@ -1063,7 +1059,6 @@ def show_points(ar,x,y,s=1,scale=50,alpha=1,pointcolor='r',open_circles=False,
     add_points(ax,d)
 
     if not returnfig:
-        plt.show()
         return
     else:
         return fig,ax


### PR DESCRIPTION
This commit fixes the show_geometry functions. Previously, there was a `plt.show()` call if the `returnfig` argument was `True`. This was a mistake, as that blocks future draws to the same figure.

By removing the `plt.show` call, the same figure can be drawn on multiple times, which is helpful when working with subplots.

I have tested this in both a Jupyter notebook as well as the IPython command line to work effectively. If you don't pass in a `figax` tuple, new figures are made as expected.

This should probably be tested by someone else before being merged to make sure it doesn't break current plotting workflows, but I think actually the effects would be minimal. 