### PR TITLE
bugfix to get_probe_synthetic

### DIFF
--- a/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
@@ -609,21 +609,39 @@ def position_detector(
 
 def get_vacuum_probe(
     self,
+    ROI = None,
     name = 'probe',
     returncalc = True,
-    **kwargs
     ):
     """
+    Computes a vacuum probe from the DataCube by aligning and averaging
+    either all or some subset of the diffraction patterns.
+
+    Args:
+        ROI (None or boolean array or tuple): if None, uses the whole
+            datacube. Otherwise, uses a subset of diffraction patterns.
+            If `ROI` is a boolean array, it should be Rspace shaped, and
+            diffraction patterns where True are used. Else should be
+            a 4-tuple representing (Rxmin,Rxmax,Rymin,Rymax) of a
+            rectangular region to use.
+
+    Returns:
+        (Probe) a Probe instance
 
     """
 
     # perform computation
     from py4DSTEM.process.probe import get_vacuum_probe
     from py4DSTEM.io.datastructure.py4dstem.probe import Probe
-    x = get_vacuum_probe(
-        self,
-        **kwargs
-    )
+    if ROI is None:
+        x = get_vacuum_probe(
+            self
+        )
+    else:
+        x = get_vacuum_probe(
+            self,
+            ROI = ROI
+        )
 
     # wrap with a py4dstem class
     x = Probe(

--- a/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
@@ -645,8 +645,7 @@ def get_vacuum_probe(
 
     # wrap with a py4dstem class
     x = Probe(
-        data = x,
-        **kwargs
+        data = x
     )
 
     # add to the tree

--- a/py4DSTEM/process/probe/probe.py
+++ b/py4DSTEM/process/probe/probe.py
@@ -332,6 +332,7 @@ def get_probe_from_vacuum_2Dimage(
 
 
 def get_probe_synthetic(
+    data,
     radius,
     width,
     Q_Nx,


### PR DESCRIPTION
Ran into an error when I wanted to make a synthetic probe using the following code:

```python
probe = py4DSTEM.process.probe.get_vacuum_probe(data=None,radius=1, width=.01, Q_Nx=dataset.shape[2], Q_Ny=dataset.shape[3])
```

Setting `data=None` should trigger the `get_synthetic_probe` code, since I didn't want to use my actual data, but it gave the following error:

<details>
    <summary>Error message</summary>

```bash
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/Users/tompekin/Documents/Research/Results/HU Postdoc/2022-11-03_sam_BaTiO/analysis.ipynb Cell 13 in <cell line: 1>()
----> [1](vscode-notebook-cell:/Users/tompekin/Documents/Research/Results/HU%20Postdoc/2022-11-03_sam_BaTiO/analysis.ipynb#X15sZmlsZQ%3D%3D?line=0) probe = py4DSTEM.process.probe.get_vacuum_probe(data=None,radius=1, width=.01, Q_Nx=dataset.shape[2], Q_Ny=dataset.shape[3])
      [2](vscode-notebook-cell:/Users/tompekin/Documents/Research/Results/HU%20Postdoc/2022-11-03_sam_BaTiO/analysis.ipynb#X15sZmlsZQ%3D%3D?line=1) py4DSTEM.show(probe, scaling='log')

File ~/Documents/Research/code/py4DSTEM/py4DSTEM/process/probe/probe.py:79, in get_vacuum_probe(data, **kwargs)
     70 functions = {
     71     '4D_full' : get_probe_from_vacuum_4Dscan,
     72     '4D_roi_mask' : get_probe_from_4Dscan_ROI_mask,
   (...)
     76     'synth' : get_probe_synthetic
     77     }
     78 fn = functions[mode]
---> 79 probe = fn(data,**kwargs)
     80 return probe

TypeError: get_probe_synthetic() got multiple values for argument 'radius'
```
 
</details>

This is fixed by making the `get_probe_synthetic` function signature match that of the other functions, where the first argument is `data`, even if `data=None`. It's kind of dumb, but it fixed the problem and allows you to keep using the dictionary-based approach in `get_vacuum_probe`.
