### PR TITLE
virtual image and calibration update

### DIFF
--- a/py4DSTEM/io/datastructure/emd/array.py
+++ b/py4DSTEM/io/datastructure/emd/array.py
@@ -177,9 +177,6 @@ class Array:
         self.dim_names = dim_names
         self.dim_units = dim_units
 
-        @property
-        def shape(self):
-            return self.data.shape
         self.rank = self.data.ndim   # rank differs from data.ndim by 1 if the Array is a stack
 
         self.tree = Tree()
@@ -290,7 +287,9 @@ class Array:
             raise Exception(f"too many dim units were passed - expected {self.rank}, received {len(self.dim_units)}")
 
 
-
+    @property
+    def shape(self):
+        return self.data.shape
 
     #### Methods
 

--- a/py4DSTEM/io/datastructure/py4dstem/calibration.py
+++ b/py4DSTEM/io/datastructure/py4dstem/calibration.py
@@ -168,6 +168,8 @@ class Calibration(Metadata):
         qx0_shift = x-qx0_mean
         self._params['qx0_mean'] = qx0_mean
         self._params['qx0_shift'] = qx0_shift
+    def set_qx0_mean(self,x):
+        self._params['qx0_mean'] = x
     def get_qx0(self,rx=None,ry=None):
         return self._get_value('qx0',rx,ry)
     def get_qx0_mean(self):
@@ -182,6 +184,8 @@ class Calibration(Metadata):
         qy0_shift = x-qy0_mean
         self._params['qy0_mean'] = qy0_mean
         self._params['qy0_shift'] = qy0_shift
+    def set_qy0_mean(self,x):
+        self._params['qy0_mean'] = x
     def get_qy0(self,rx=None,ry=None):
         return self._get_value('qy0',rx,ry)
     def get_qy0_mean(self):
@@ -264,8 +268,8 @@ class Calibration(Metadata):
         """
         probe_semiangle, qx0, qy0 = x
         self.set_probe_semiangle(probe_semiangle)
-        self.set_qx0(qx0)
-        self.set_qy0(qy0)
+        self.set_qx0_mean(qx0)
+        self.set_qy0_mean(qy0)
     def get_probe_param(self):
         probe_semiangle = self._get_value('probe_semiangle')
         qx0 = self._get_value('qx0')

--- a/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
@@ -417,11 +417,10 @@ def get_virtual_image(
             no effect. Default is False.
         shift_center (bool): if True, the mask is shifted at each real space
             position to account for any shifting of the origin of the diffraction
-            images. The datacube's calibration['origin'] parameter must be set
-            (centered = True). The shift applied to each pattern is the
-            difference between the local origin position and the mean origin
-            position over all patterns, rounded to the nearest integer for speed.
-            Default is False.
+            images. The datacube's calibration['origin'] parameter must be set. 
+            The shift applied to each pattern is the difference between the local 
+            origin position and the mean origin position over all patterns, 
+            rounded to the nearest integer for speed. Default is False.
         verbose (bool): if True, show progress bar
         dask (bool): if True, use dask arrays
         return_mask (bool): if False (default) returns a virtual image as usual.
@@ -512,10 +511,10 @@ def position_detector(
             no effect. 
         shift_center (bool): if True, the mask is shifted at each real space
             position to account for any shifting of the origin of the diffraction
-            images. The datacube's calibration['origin'] parameter must be set
-            (centered = True). The shift applied to each pattern is the
-            difference between the local origin position and the mean origin
-            position over all patterns, rounded to the nearest integer for speed.
+            images. The datacube's calibration['origin'] parameter must be set. 
+            The shift applied to each pattern is the difference between the local 
+            origin position and the mean origin position over all patterns, 
+            rounded to the nearest integer for speed.
     """
   
     # parse inputs
@@ -524,7 +523,7 @@ def position_detector(
         shift_center = False
     else:
         data = (self,scan_position[0],scan_position[1])
-        
+
     # make and show visualization
     from py4DSTEM.visualize import position_detector
     position_detector(

--- a/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
@@ -396,7 +396,7 @@ def get_virtual_image(
             - 'annular' or 'annulus' uses annular detector, like dark field
             - 'rectangle', 'square', 'rectangular', uses rectangular detector
             - 'mask' flexible detector, any 2D array
-    geometry (variable) : valid entries are determined by the `mode`, values in
+        geometry (variable) : valid entries are determined by the `mode`, values in
         pixels argument, as follows:
             - 'point': 2-tuple, (qx,qy), ints
             - 'circle' or 'circular': nested 2-tuple, ((qx,qy),radius),
@@ -424,8 +424,8 @@ def get_virtual_image(
             (centered = True). The shift applied to each pattern is the
             difference between the local origin position and the mean origin
             position over all patterns, rounded to the nearest integer for speed.
-            Default is None and will set to True if centered == True and the origin
-            is set to match datacube.Rshape. Default is False.
+            Default is None and will set to True if the origin is set for each position 
+            in real space. Default is False.
         verbose (bool): if True, show progress bar
         dask (bool): if True, use dask arrays
         return_mask (bool): if False (default) returns a virtual image as usual.
@@ -461,7 +461,7 @@ def get_virtual_image(
 
     # logic to determine shift_center
     if shift_center is None:
-        if centered and self.calibration.get_origin()[0].shape == self.Rshape:
+        if self.calibration.get_origin()[0].shape == self.Rshape:
             shift_center = True
         else:
             shift_center = False
@@ -570,14 +570,14 @@ def position_detector(
 
     #check for calibration and set function configutions
     if calibrated is None:
-        if self.calibration.get_qx0_mean() and self.calibration.get_qy0_mean():
+        if self.calibration['Q_pixel_units'] == 'A^-1' and 'qx0' in self.calibration.keys:
             calibrated = True
         else:
             calibrated = False
 
     #check for centered 
     if centered is None:
-        if self.calibration.get_origin() and self.calibration.get_origin()[0].shape == self.Rshape:
+        if self.calibration.get_qx0_mean() and self.calibration.get_qy0_mean():
             centered = True
         else:
             centered = False

--- a/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
@@ -408,24 +408,20 @@ def get_virtual_image(
         centered (bool): if False, the origin is in the upper left corner.
              If True, the origin is set to the mean origin in the datacube
              calibrations, so that a bright-field image could be specified
-             with, e.g., geometry = ((0,0),R). If `None` is passed, checks
-             the calibrations and sets to True if the mean origin is found,
-             and False if not.  The origin can set with
+             with, e.g., geometry = ((0,0),R).  The origin can set with
              datacube.calibration.set_origin().  For `mode="mask"`,
              has no effect. Default is False.
         calibrated (bool): if True, geometry is specified in units of 'A^-1'
             instead of pixels. The datacube's calibrations must have its
             `"Q_pixel_units"` parameter set to "A^-1". For `mode="mask"`, has
-            no effect. If None will set to True if the calibration
-            has been set. Default is False.
+            no effect. Default is False.
         shift_center (bool): if True, the mask is shifted at each real space
             position to account for any shifting of the origin of the diffraction
             images. The datacube's calibration['origin'] parameter must be set
             (centered = True). The shift applied to each pattern is the
             difference between the local origin position and the mean origin
             position over all patterns, rounded to the nearest integer for speed.
-            Default is None and will set to True if the origin is set for each position 
-            in real space. Default is False.
+            Default is False.
         verbose (bool): if True, show progress bar
         dask (bool): if True, use dask arrays
         return_mask (bool): if False (default) returns a virtual image as usual.
@@ -439,40 +435,9 @@ def get_virtual_image(
             add anything to the datacube's tree.
         name (str): the output object's name
         returncalc (bool): if True, returns the output
-        test_config: if True, returns the Boolean value of (`centered`,
-            `calibrated`,`shift_center`). Does not compute the virtual image.
-
     Returns:
         (Optional): if returncalc is True, returns the VirtualImage
     """
-    #check for calibration and set function configutions
-    if calibrated is None:
-        if self.calibration['Q_pixel_units'] == 'A^-1' and 'qx0' in self.calibration.keys:
-            calibrated = True
-        else:
-            calibrated = False
-
-    #check for centered 
-    if centered is None:
-        if self.calibration.get_qx0_mean() and self.calibration.get_qy0_mean():
-            centered = True
-        else:
-            centered = False
-
-    # logic to determine shift_center
-    if shift_center is None:
-        if self.calibration.get_origin()[0].shape == self.Rshape:
-            shift_center = True
-        else:
-            shift_center = False
-
-    if test_config:
-        for x,y in zip(['centered','calibrated','shift_center'],
-                       [centered,calibrated,shift_center]):
-            print(f"{x} = {y}")
-        return
-
-
     # perform computation
     from py4DSTEM.process.virtualimage import get_virtual_image
     im = get_virtual_image(
@@ -538,57 +503,20 @@ def position_detector(
         centered (bool): if False, the origin is in the upper left corner.
              If True, the origin is set to the mean origin in the datacube
              calibrations, so that a bright-field image could be specified
-             with, e.g., geometry = ((0,0),R). If `None` is passed, checks
-             the calibrations and sets to True if the mean origin is found,
-             and False if not.  The origin can set with
+             with, e.g., geometry = ((0,0),R). The origin can set with
              datacube.calibration.set_origin().  For `mode="mask"`,
-             has no effect. Default is None.
+             has no effect. Default is False.
         calibrated (bool): if True, geometry is specified in units of 'A^-1'
             instead of pixels. The datacube's calibrations must have its
             `"Q_pixel_units"` parameter set to "A^-1". For `mode="mask"`, has
-            no effect. Default is None and will set to True if the calibration
-            has been set.
+            no effect. 
         shift_center (bool): if True, the mask is shifted at each real space
             position to account for any shifting of the origin of the diffraction
             images. The datacube's calibration['origin'] parameter must be set
             (centered = True). The shift applied to each pattern is the
             difference between the local origin position and the mean origin
             position over all patterns, rounded to the nearest integer for speed.
-            Default is None and will set to True if centered == True and the origin
-            is set to match datacube.Rshape.
-        test_config: if True, performs no calculations; instead, checks the
-            dataset's calibrations and prints to screen which calibrations
-            will be applied when the function is run.
     """
-    # parse inputs
-    if scan_position is None:
-        data = self
-        shift_center = False
-    else:
-        data = (self,scan_position[0],scan_position[1])
-        shift_center = True
-
-    #check for calibration and set function configutions
-    if calibrated is None:
-        if self.calibration['Q_pixel_units'] == 'A^-1' and 'qx0' in self.calibration.keys:
-            calibrated = True
-        else:
-            calibrated = False
-
-    #check for centered 
-    if centered is None:
-        if self.calibration.get_qx0_mean() and self.calibration.get_qy0_mean():
-            centered = True
-        else:
-            centered = False
-
-    if test_config:
-        for x,y in zip(['centered','calibrated','shift_center'],
-                       [centered,calibrated,shift_center]):
-            print(f"{x} = {y}")
-        return
-
-
     # make and show visualization
     from py4DSTEM.visualize import position_detector
     position_detector(
@@ -601,8 +529,6 @@ def position_detector(
         color = 'r',
         alpha = 0.4
     )
-
-
 
 
 

--- a/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
@@ -375,9 +375,9 @@ def get_virtual_image(
     self,
     mode,
     geometry,
-    centered = None,
-    calibrated = None,
-    shift_center = None,
+    centered = False,
+    calibrated = False,
+    shift_center = False,
     verbose = True,
     dask = False,
     return_mask = False,
@@ -412,19 +412,20 @@ def get_virtual_image(
              the calibrations and sets to True if the mean origin is found,
              and False if not.  The origin can set with
              datacube.calibration.set_origin().  For `mode="mask"`,
-             has no effect. Default is None.
+             has no effect. Default is False.
         calibrated (bool): if True, geometry is specified in units of 'A^-1'
             instead of pixels. The datacube's calibrations must have its
             `"Q_pixel_units"` parameter set to "A^-1". For `mode="mask"`, has
-            no effect. Default is None and will set to True if the calibration
-            has been set.
+            no effect. If None will set to True if the calibration
+            has been set. Default is False.
         shift_center (bool): if True, the mask is shifted at each real space
             position to account for any shifting of the origin of the diffraction
             images. The datacube's calibration['origin'] parameter must be set
             (centered = True). The shift applied to each pattern is the
             difference between the local origin position and the mean origin
             position over all patterns, rounded to the nearest integer for speed.
-            Default is None and will set to True if centered == True.
+            Default is None and will set to True if centered == True and the origin
+            is set to match datacube.Rshape. Default is False.
         verbose (bool): if True, show progress bar
         dask (bool): if True, use dask arrays
         return_mask (bool): if False (default) returns a virtual image as usual.
@@ -460,7 +461,7 @@ def get_virtual_image(
 
     # logic to determine shift_center
     if shift_center is None:
-        if centered:
+        if centered and self.calibration.get_origin()[0].shape == self.Rshape:
             shift_center = True
         else:
             shift_center = False
@@ -553,7 +554,8 @@ def position_detector(
             (centered = True). The shift applied to each pattern is the
             difference between the local origin position and the mean origin
             position over all patterns, rounded to the nearest integer for speed.
-            Default is None and will set to True if centered == True.
+            Default is None and will set to True if centered == True and the origin
+            is set to match datacube.Rshape.
         test_config: if True, performs no calculations; instead, checks the
             dataset's calibrations and prints to screen which calibrations
             will be applied when the function is run.
@@ -575,7 +577,7 @@ def position_detector(
 
     #check for centered 
     if centered is None:
-        if self.calibration.get_origin():
+        if self.calibration.get_origin() and self.calibration.get_origin()[0].shape == self.Rshape:
             centered = True
         else:
             centered = False

--- a/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
@@ -454,7 +454,7 @@ def get_virtual_image(
 
     #check for centered 
     if centered is None:
-        if self.calibration.get_origin():
+        if self.calibration.get_qx0_mean() and self.calibration.get_qy0_mean():
             centered = True
         else:
             centered = False
@@ -570,7 +570,7 @@ def position_detector(
 
     #check for calibration and set function configutions
     if calibrated is None:
-        if self.calibration['Q_pixel_units'] == 'A^-1' and 'qx0' in self.calibration.keys:
+        if self.calibration.get_qx0_mean() and self.calibration.get_qy0_mean():
             calibrated = True
         else:
             calibrated = False

--- a/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
@@ -517,6 +517,14 @@ def position_detector(
             difference between the local origin position and the mean origin
             position over all patterns, rounded to the nearest integer for speed.
     """
+  
+    # parse inputs
+    if scan_position is None:
+        data = self
+        shift_center = False
+    else:
+        data = (self,scan_position[0],scan_position[1])
+        
     # make and show visualization
     from py4DSTEM.visualize import position_detector
     position_detector(

--- a/py4DSTEM/process/virtualimage.py
+++ b/py4DSTEM/process/virtualimage.py
@@ -103,6 +103,18 @@ def get_virtual_image(
 
     # no center shifting
     if shift_center == False:
+        if centered == True: 
+            assert datacube.calibration.get_origin_shift(), "origin need to be calibrated"
+            qx_shift,qy_shift = datacube.calibration.get_origin_shift()
+            if not np.isscalar(qx_shift): 
+                qx_shift = np.mean(qx_shift)
+                qy_shift = np.mean(qy_shift)
+
+            mask = np.roll(
+                mask,
+                (qx_shift, qy_shift),
+                axis=(0,1)
+            )
 
         # dask 
         if dask == True:
@@ -140,6 +152,7 @@ def get_virtual_image(
 
         # get shifts
         assert datacube.calibration.get_origin_shift(), "origin need to be calibrated"
+        assert datacube.calibration.get_origin_shift()[0].shape == datacube.Rshape, "origin need to be calibrated"
         qx_shift,qy_shift = datacube.calibration.get_origin_shift()
         qx_shift = qx_shift.round().astype(int)
         qy_shift = qy_shift.round().astype(int)

--- a/py4DSTEM/process/virtualimage.py
+++ b/py4DSTEM/process/virtualimage.py
@@ -103,19 +103,6 @@ def get_virtual_image(
 
     # no center shifting
     if shift_center == False:
-        if centered == True: 
-            assert datacube.calibration.get_origin_shift(), "origin need to be calibrated"
-            qx_shift,qy_shift = datacube.calibration.get_origin_shift()
-            if not np.isscalar(qx_shift): 
-                qx_shift = np.mean(qx_shift)
-                qy_shift = np.mean(qy_shift)
-
-            mask = np.roll(
-                mask,
-                (qx_shift, qy_shift),
-                axis=(0,1)
-            )
-
         # dask 
         if dask == True:
 
@@ -233,9 +220,9 @@ def get_calibrated_geometry(
 
     # Get calibration metadata
     if centered:
-        assert cal.get_origin(), "origin need to be calibrated"
-        x0, y0 = cal.get_origin()
+        assert cal.get_qx0_mean(), "origin need to be calibrated" 
         x0_mean, y0_mean = cal.get_origin_mean()
+
     if calibrated:
         assert cal['Q_pixel_units'] == 'A^-1', \
         'check calibration - must be calibrated in A^-1 to use `calibrated=True`'

--- a/py4DSTEM/process/virtualimage.py
+++ b/py4DSTEM/process/virtualimage.py
@@ -139,7 +139,6 @@ def get_virtual_image(
 
         # get shifts
         assert datacube.calibration.get_origin_shift(), "origin need to be calibrated"
-        assert datacube.calibration.get_origin_shift()[0].shape == datacube.Rshape, "origin need to be calibrated"
         qx_shift,qy_shift = datacube.calibration.get_origin_shift()
         qx_shift = qx_shift.round().astype(int)
         qy_shift = qy_shift.round().astype(int)

--- a/py4DSTEM/process/virtualimage.py
+++ b/py4DSTEM/process/virtualimage.py
@@ -219,7 +219,7 @@ def get_calibrated_geometry(
 
     # Get calibration metadata
     if centered:
-        assert cal.get_qx0_mean(), "origin need to be calibrated" 
+        assert cal.get_qx0_mean(), "origin needs to be calibrated" 
         x0_mean, y0_mean = cal.get_origin_mean()
 
     if calibrated:

--- a/py4DSTEM/visualize/virtualimage.py
+++ b/py4DSTEM/visualize/virtualimage.py
@@ -72,7 +72,6 @@ def position_detector(
             assert isinstance(image, np.ndarray)
             assert isinstance(cal, Calibration)
         elif len(data)==3:
-            assert(shift_center is True), "If `data` is a 3-tuple, `shift_center` must be True"
             data,rx,ry = data
             image = data[rx,ry,:,:]
             cal = data.calibration

--- a/py4DSTEM/visualize/vis_special.py
+++ b/py4DSTEM/visualize/vis_special.py
@@ -809,24 +809,24 @@ def show_complex(
         ar_complex (2d array)   : complex array to be plotted
         vmin (float, optional)  : minimum absolute value 
         vmax (float, optional)  : maximum absolute value 
+        vmin/vmax are set to fractions of the distribution of pixel values in the array, e.g. 
+        vmin=0.02 will set the minumum display value to saturate the lower 2% of pixels
         cbar (bool)             : if True, include color wheel
         returnfig (bool)        : if True, the function returns the tuple (figure,axis)
-
+        
     Returns:
         if returnfig==False (default), the figure is plotted and nothing is returned.
         if returnfig==True, return the figure and the axis.
     '''
 
     #define min and max
-    amp = np.abs(ar_complex)
+    amp = np.abs(ar_complex)  
     if np.max(amp) == np.min(amp):
         if vmin is None: vmin = 0 
         if vmax is None: vmax = np.max(amp)
     else:
         if vmin is None: vmin = 0.02
         if vmax is None: vmax = 0.98
-        ind_vmin = np.round((amp.shape[0]-1)*vmin).astype('int')
-        ind_vmax = np.round((amp.shape[0]-1)*vmax).astype('int')
         vals = np.sort(amp[~np.isnan(amp)])
         ind_vmin = np.round((vals.shape[0]-1)*vmin).astype('int')
         ind_vmax = np.round((vals.shape[0]-1)*vmax).astype('int')
@@ -858,6 +858,9 @@ def show_complex(
     #plot
     fig, ax = show(
         rgb,
+        vmin = 0, 
+        vmax = 1,
+        intensity_range= 'absolute',
         returnfig = True,
         **kwargs
     )

--- a/py4DSTEM/visualize/vis_special.py
+++ b/py4DSTEM/visualize/vis_special.py
@@ -819,11 +819,22 @@ def show_complex(
 
     #define min and max
     amp = np.abs(ar_complex)
-    if vmin is None: 
-        vmin = np.min(amp)*0.98
-    if vmax is None: 
-        vmax = np.max(amp)*0.02
-    
+    if np.max(amp) == np.min(amp):
+        if vmin is None: vmin = 0 
+        if vmax is None: vmax = np.max(amp)
+    else:
+        if vmin is None: vmin = 0.02
+        if vmax is None: vmax = 0.98
+        ind_vmin = np.round((amp.shape[0]-1)*vmin).astype('int')
+        ind_vmax = np.round((amp.shape[0]-1)*vmax).astype('int')
+        vals = np.sort(amp[~np.isnan(amp)])
+        ind_vmin = np.round((vals.shape[0]-1)*vmin).astype('int')
+        ind_vmax = np.round((vals.shape[0]-1)*vmax).astype('int')
+        ind_vmin = np.max([0,ind_vmin])
+        ind_vmax = np.min([len(vals)-1,ind_vmax])
+        vmin = vals[ind_vmin]
+        vmax = vals[ind_vmax]
+
     from matplotlib.colors import hsv_to_rgb
 
     #function for converting to complex colors

--- a/py4DSTEM/visualize/vis_special.py
+++ b/py4DSTEM/visualize/vis_special.py
@@ -820,9 +820,9 @@ def show_complex(
     #define min and max
     amp = np.abs(ar_complex)
     if vmin is None: 
-        vmin = np.min(amp)
+        vmin = np.min(amp)*0.98
     if vmax is None: 
-        vmax = np.max(amp)
+        vmax = np.max(amp)*0.02
     
     from matplotlib.colors import hsv_to_rgb
 


### PR DESCRIPTION
This PR includes: 
- removing the logic for `get_virtual_image` and `position_detector`
- update to `virtualimage` such that the mean qx0 and qy0 can be used to center the detector 
- update calibration for `get_vacuum_probe`
- add setter for `set_qx0_mean` and `set_qy0_mean`
- change defaults for `show_complex`

[virtual_detector_test.ipynb.zip](https://github.com/py4dstem/py4DSTEM/files/10247242/virtual_detector_test.ipynb.zip)
