### PR TITLE
Preprocessing method updates and Array.shape patch

### DIFF
--- a/py4DSTEM/io/datastructure/emd/array.py
+++ b/py4DSTEM/io/datastructure/emd/array.py
@@ -177,27 +177,17 @@ class Array:
         self.dim_names = dim_names
         self.dim_units = dim_units
 
-        self.rank = self.data.ndim   # rank differs from data.ndim by 1 if the Array is a stack
-
         self.tree = Tree()
         if not hasattr(self, "_metadata"):
             self._metadata = {}
-
-        # flag to help assign dim names and units
-        dim_in_pixels = np.zeros(self.rank, dtype=bool)
 
 
         ## Handle array stacks
 
         if slicelabels is None:
-            self.depth = 0
             self.is_stack = False
 
         else:
-            self.depth = self.shape[-1]
-            self.shape = self.shape[:-1]
-            dim_in_pixels = dim_in_pixels[:-1]
-            self.rank -= 1
             self.is_stack = True
 
             # Populate labels
@@ -215,6 +205,7 @@ class Array:
 
         ## Set dim vectors
 
+        dim_in_pixels = np.zeros(self.rank, dtype=bool) # flag to help assign dim names and units
         # if none were passed
         if self.dims is None:
             self.dims = [self._unpack_dim(1,self.shape[n]) for n in range(self.rank)]
@@ -287,11 +278,28 @@ class Array:
             raise Exception(f"too many dim units were passed - expected {self.rank}, received {len(self.dim_units)}")
 
 
+    # Shape properties
+
     @property
     def shape(self):
-        return self.data.shape
+        if not self.is_stack:
+            return self.data.shape
+        else:
+            return self.data.shape[:-1]
 
-    #### Methods
+    @property
+    def depth(self):
+        if not self.is_stack:
+            return 0
+        else:
+            return self.data.shape[-1]
+
+    @property
+    def rank(self):
+        if not self.is_stack:
+            return self.data.ndim
+        else:
+            return self.data.ndim - 1
 
 
     ## Slicing

--- a/py4DSTEM/io/datastructure/py4dstem/datacube.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube.py
@@ -13,8 +13,19 @@ class DataCube(Array):
     Stores 4D-STEM datasets.
     """
 
+    # import class methods
     from py4DSTEM.io.datastructure.py4dstem.datacube_fns import (
         add,
+        set_scan_shape,
+        swap_RQ,
+        swap_Rxy,
+        swap_Qxy,
+        crop_Q,
+        crop_R,
+        bin_Q,
+        bin_Q_mmap,
+        bin_R,
+        filter_hot_pixels,
         get_virtual_diffraction,
         get_dp_max,
         get_dp_mean,

--- a/py4DSTEM/io/datastructure/py4dstem/datacube.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube.py
@@ -25,6 +25,7 @@ class DataCube(Array):
         bin_Q,
         bin_Q_mmap,
         bin_R,
+        thin_R,
         filter_hot_pixels,
         get_virtual_diffraction,
         get_dp_max,

--- a/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
@@ -26,7 +26,6 @@ def add(
 
 
 # Preprocessing
-from py4DSTEM import preprocess
 
 def set_scan_shape(
     self,
@@ -38,8 +37,9 @@ def set_scan_shape(
     Accepts:
         Rshape (2-tuple)
     """
+    from py4DSTEM.preprocess import set_scan_shape
     assert len(Rshape)==2, "Rshape must have a length of 2"
-    d = preprocess.set_scan_shape(self,Rshape[0],Rshape[1])
+    d = set_scan_shape(self,Rshape[0],Rshape[1])
     return d
 
 def swap_RQ(
@@ -48,7 +48,8 @@ def swap_RQ(
     """
     Swaps the first and last two dimensions of the 4D datacube.
     """
-    d = preprocess.swap_RQ(self)
+    from py4DSTEM.preprocess import swap_RQ
+    d = swap_RQ(self)
     return d
 
 def swap_Rxy(
@@ -57,7 +58,8 @@ def swap_Rxy(
     """
     Swaps the real space x and y coordinates.
     """
-    d = preprocess.swap_Rxy(self)
+    from py4DSTEM.preprocess import swap_Rxy
+    d = swap_Rxy(self)
     return d
 
 def swap_Qxy(
@@ -66,7 +68,8 @@ def swap_Qxy(
     """
     Swaps the diffraction space x and y coordinates.
     """
-    d = preprocess.swap_Qxy(self)
+    from py4DSTEM.preprocess import swap_Qxy
+    d = swap_Qxy(self)
     return d
 
 def crop_Q(
@@ -79,8 +82,9 @@ def crop_Q(
     Accepts:
         ROI (4-tuple): Specifies (Qx_min,Qx_max,Qy_min,Qy_max)
     """
+    from py4DSTEM.preprocess import crop_data_diffraction
     assert len(ROI)==4, "Crop region `ROI` must have length 4"
-    d = preprocess.crop_data_diffraction(self,ROI[0],ROI[1],ROI[2],ROI[3])
+    d = crop_data_diffraction(self,ROI[0],ROI[1],ROI[2],ROI[3])
     return d
 
 def crop_R(
@@ -93,8 +97,9 @@ def crop_R(
     Accepts:
         ROI (4-tuple): Specifies (Rx_min,Rx_max,Ry_min,Ry_max)
     """
+    from py4DSTEM.preprocess import crop_data_real
     assert len(ROI)==4, "Crop region `ROI` must have length 4"
-    d = preprocess.crop_data_real(self,ROI[0],ROI[1],ROI[2],ROI[3])
+    d = crop_data_real(self,ROI[0],ROI[1],ROI[2],ROI[3])
     return d
 
 def bin_Q(
@@ -107,7 +112,8 @@ def bin_Q(
     Accepts:
         N (int): the binning factor
     """
-    d = preprocess.bin_data_diffraction(self,N)
+    from py4DSTEM.preprocess import bin_data_diffraction
+    d = bin_data_diffraction(self,N)
     return d
 
 def bin_R(
@@ -120,7 +126,8 @@ def bin_R(
     Accepts:
         N (int): the binning factor
     """
-    d = preprocess.bin_data_real(self,N)
+    from py4DSTEM.preprocess import bin_data_real
+    d = bin_data_real(self,N)
     return d
 
 def bin_Q_mmap(
@@ -135,7 +142,8 @@ def bin_Q_mmap(
         N (int): the binning factor
         dtype: the data type
     """
-    d = preprocess.bin_data_mmap(self,N)
+    from py4DSTEM.preprocess import bin_data_mmap
+    d = bin_data_mmap(self,N)
     return d
 
 def filter_hot_pixels(
@@ -161,7 +169,8 @@ def filter_hot_pixels(
         datacube (DataCube)
         mask (optional, boolean Array) the bad pixel mask
     """
-    d = preprocess.filter_hot_pixels(
+    from py4DSTEM.preprocess import filter_hot_pixels
+    d = filter_hot_pixels(
         self,
         thresh,
         ind_compare,

--- a/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
@@ -116,20 +116,6 @@ def bin_Q(
     d = bin_data_diffraction(self,N)
     return d
 
-def bin_R(
-    self,
-    N
-    ):
-    """
-    Bins the data in real space by bin factor N
-
-    Accepts:
-        N (int): the binning factor
-    """
-    from py4DSTEM.preprocess import bin_data_real
-    d = bin_data_real(self,N)
-    return d
-
 def bin_Q_mmap(
     self,
     N,
@@ -144,6 +130,34 @@ def bin_Q_mmap(
     """
     from py4DSTEM.preprocess import bin_data_mmap
     d = bin_data_mmap(self,N)
+    return d
+
+def bin_R(
+    self,
+    N
+    ):
+    """
+    Bins the data in real space by bin factor N
+
+    Accepts:
+        N (int): the binning factor
+    """
+    from py4DSTEM.preprocess import bin_data_real
+    d = bin_data_real(self,N)
+    return d
+
+def thin_R(
+    self,
+    N
+    ):
+    """
+    Reduces the data in real space by skipping every N patterns in the x and y directions.
+
+    Accepts:
+        N (int): the thinning factor
+    """
+    from py4DSTEM.preprocess import thin_data_real
+    d = thin_data_real(self,N)
     return d
 
 def filter_hot_pixels(

--- a/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/datacube_fns.py
@@ -25,6 +25,154 @@ def add(
     self.tree[data.name] = data
 
 
+# Preprocessing
+from py4DSTEM import preprocess
+
+def set_scan_shape(
+    self,
+    Rshape
+    ):
+    """
+    Reshape the data given the real space scan shape.
+
+    Accepts:
+        Rshape (2-tuple)
+    """
+    assert len(Rshape)==2, "Rshape must have a length of 2"
+    d = preprocess.set_scan_shape(self,Rshape[0],Rshape[1])
+    return d
+
+def swap_RQ(
+    self
+    ):
+    """
+    Swaps the first and last two dimensions of the 4D datacube.
+    """
+    d = preprocess.swap_RQ(self)
+    return d
+
+def swap_Rxy(
+    self
+    ):
+    """
+    Swaps the real space x and y coordinates.
+    """
+    d = preprocess.swap_Rxy(self)
+    return d
+
+def swap_Qxy(
+    self
+    ):
+    """
+    Swaps the diffraction space x and y coordinates.
+    """
+    d = preprocess.swap_Qxy(self)
+    return d
+
+def crop_Q(
+    self,
+    ROI
+    ):
+    """
+    Crops the data in diffraction space about the region specified by ROI.
+
+    Accepts:
+        ROI (4-tuple): Specifies (Qx_min,Qx_max,Qy_min,Qy_max)
+    """
+    assert len(ROI)==4, "Crop region `ROI` must have length 4"
+    d = preprocess.crop_data_diffraction(self,ROI[0],ROI[1],ROI[2],ROI[3])
+    return d
+
+def crop_R(
+    self,
+    ROI
+    ):
+    """
+    Crops the data in real space about the region specified by ROI.
+
+    Accepts:
+        ROI (4-tuple): Specifies (Rx_min,Rx_max,Ry_min,Ry_max)
+    """
+    assert len(ROI)==4, "Crop region `ROI` must have length 4"
+    d = preprocess.crop_data_real(self,ROI[0],ROI[1],ROI[2],ROI[3])
+    return d
+
+def bin_Q(
+    self,
+    N
+    ):
+    """
+    Bins the data in diffraction space by bin factor N
+
+    Accepts:
+        N (int): the binning factor
+    """
+    d = preprocess.bin_data_diffraction(self,N)
+    return d
+
+def bin_R(
+    self,
+    N
+    ):
+    """
+    Bins the data in real space by bin factor N
+
+    Accepts:
+        N (int): the binning factor
+    """
+    d = preprocess.bin_data_real(self,N)
+    return d
+
+def bin_Q_mmap(
+    self,
+    N,
+    dtype=np.float32
+    ):
+    """
+    Bins the data in diffraction space by bin factor N for memory mapped data
+
+    Accepts:
+        N (int): the binning factor
+        dtype: the data type
+    """
+    d = preprocess.bin_data_mmap(self,N)
+    return d
+
+def filter_hot_pixels(
+    self,
+    thresh,
+    ind_compare=1,
+    return_mask=False
+    ):
+    """
+    This function performs pixel filtering to remove hot / bright pixels. We first compute a moving local ordering filter,
+    applied to the mean diffraction image. This ordering filter will return a single value from the local sorted intensity
+    values, given by ind_compare. ind_compare=0 would be the highest intensity, =1 would be the second hightest, etc.
+    Next, a mask is generated for all pixels which are least a value thresh higher than the local ordering filter output.
+    Finally, we loop through all diffraction images, and any pixels defined by mask are replaced by their 3x3 local median.
+
+    Args:
+        datacube (DataCube):
+        thresh (float): threshold for replacing hot pixels, if pixel value minus local ordering filter exceeds it.
+        ind_compare (int): which median filter value to compare against. 0 = brightest pixel, 1 = next brightest, etc.
+        return_mask (bool): if True, returns the filter mask
+
+    Returns:
+        datacube (DataCube)
+        mask (optional, boolean Array) the bad pixel mask
+    """
+    d = preprocess.filter_hot_pixels(
+        self,
+        thresh,
+        ind_compare,
+        return_mask,
+    )
+    return d
+
+
+
+
+
 
 # Diffraction imaging
 

--- a/py4DSTEM/preprocess/preprocess.py
+++ b/py4DSTEM/preprocess/preprocess.py
@@ -165,15 +165,6 @@ def thin_data_real(datacube, thinning_factor):
     return datacube
 
 
-
-#        binned_diffraction_image = py4DSTEM.preprocess.bin2D(
-#            diffraction_image,
-#            N_Q
-#        )
-
-#        data[rx,ry,:,:] = binned_diffraction_image
-
-
 def filter_hot_pixels(
     datacube,
     thresh,

--- a/py4DSTEM/preprocess/preprocess.py
+++ b/py4DSTEM/preprocess/preprocess.py
@@ -141,6 +141,39 @@ def bin_data_real(datacube, bin_factor):
         datacube.data = datacube.data.reshape(int(R_Nx/bin_factor),bin_factor,int(R_Ny/bin_factor),bin_factor,Q_Nx,Q_Ny).sum(axis=(1,3))
         return datacube
 
+def thin_data_real(datacube, thinning_factor):
+    """
+    Reduces data size by a factor of `thinning_factor`^2 by skipping every `thinning_factor` beam positions in both x and y.
+    """
+    Rshape0 = datacube.Rshape
+    Rshapef = tuple([x//thinning_factor for x in Rshape0])
+
+    # allocate memory
+    data = np.empty(
+        (Rshapef[0],Rshapef[1],datacube.Qshape[0],datacube.Qshape[1]),
+        dtype = datacube.data.dtype
+    )
+
+    # populate data
+    for rx,ry in tqdmnd(Rshapef[0],Rshapef[1]):
+
+        rx0 = rx*thinning_factor
+        ry0 = ry*thinning_factor
+        data[rx,ry,:,:] = datacube[rx0,ry0,:,:]
+
+    datacube.data = data
+    return datacube
+
+
+
+#        binned_diffraction_image = py4DSTEM.preprocess.bin2D(
+#            diffraction_image,
+#            N_Q
+#        )
+
+#        data[rx,ry,:,:] = binned_diffraction_image
+
+
 def filter_hot_pixels(
     datacube,
     thresh,

--- a/py4DSTEM/preprocess/preprocess.py
+++ b/py4DSTEM/preprocess/preprocess.py
@@ -155,13 +155,14 @@ def filter_hot_pixels(
     Finally, we loop through all diffraction images, and any pixels defined by mask are replaced by their 3x3 local median.
 
     Args:
-            datacube (DataCube):      py4DSTEM Datacube
-            thresh (float):           threshold for replacing hot pixels, if pixel value minus local ordering filter exceeds it.
-            ind_compare (int):        which median filter value to compare against. 0 = brightest pixel, 1 = next brightest, etc.
+        datacube (DataCube):      py4DSTEM Datacube
+        thresh (float):           threshold for replacing hot pixels, if pixel value minus local ordering filter exceeds it.
+        ind_compare (int):        which median filter value to compare against. 0 = brightest pixel, 1 = next brightest, etc.
+        return_mask (bool): if True, returns the filter mask
 
-        Returns:
-            datacube                     datacube
-            mask (bool):                 (optional) the bad pixel mask
+    Returns:
+        datacube                     datacube
+        mask (bool):                 (optional) the bad pixel mask
     """
 
     # Mean image over all probe positions


### PR DESCRIPTION
This PR:
- links all datacube preprocessing functions from py4DSTEM.preprocess as DataCube methods
- adds a new preprocessing method DataCube.thin_R which downsamples by stride, i.e. skipping patterns, rather than binning
- fixes issue #369, turning all Array shape related attributes into `@property` methods which point to the relevant aspect of Array.shape