### PR TITLE
image grid and Bragg vector calibration fixes

### DIFF
--- a/py4DSTEM/io/datastructure/py4dstem/braggvectors_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/braggvectors_fns.py
@@ -320,7 +320,8 @@ def index_bragg_directions(
     """
     From an origin (x0,y0), a set of reciprocal lattice vectors gx,gy, and an pair of
     lattice vectors g1=(g1x,g1y), g2=(g2x,g2y), find the indices (h,k) of all the
-    reciprocal lattice directions.
+    reciprocal lattice directions. In units of pixels. If calibrated in A^-1, also stores
+    `self.braggdirections_calibrated.` 
 
     Args:
         x0 (float): x-coord of origin

--- a/py4DSTEM/io/datastructure/py4dstem/braggvectors_fns.py
+++ b/py4DSTEM/io/datastructure/py4dstem/braggvectors_fns.py
@@ -357,7 +357,6 @@ def index_bragg_directions(
             braggdirections['h'],
             braggdirections['k'],
             ))
-
         self.braggdirections_calibrated = braggdirections_calibrated
 
     if plot:
@@ -408,7 +407,6 @@ def add_indices_to_braggpeaks(
             qx_shift = self.Qshape[0]/2* self.calibration.get_Q_pixel_size(),
             qy_shift = self.Qshape[1]/2* self.calibration.get_Q_pixel_size(),
         )
-
     else:
         bragg_peaks_indexed = add_indices_to_braggpeaks(
             self.vectors,

--- a/py4DSTEM/visualize/show.py
+++ b/py4DSTEM/visualize/show.py
@@ -1116,7 +1116,7 @@ def show_annuli(ar,center,radii,color='r',fill=True,alpha=0.3,linewidth=2,return
         return fig,ax
 
 def show_points(ar,x,y,s=1,scale=50,alpha=1,pointcolor='r',open_circles=False,
-                returnfig=False,**kwargs):
+                title = None, returnfig=False,**kwargs):
     """
     Plots a 2D array with one or more points.
     x and y are the point centers and must have the same length, N.
@@ -1129,6 +1129,7 @@ def show_points(ar,x,y,s=1,scale=50,alpha=1,pointcolor='r',open_circles=False,
         x,y         (number or iterable of numbers) the point positions
         s           (number or iterable of numbers) the relative point sizes
         scale       (number) the maximum point size
+        title       (str)  title for plot
         pointcolor
         alpha
 
@@ -1137,7 +1138,7 @@ def show_points(ar,x,y,s=1,scale=50,alpha=1,pointcolor='r',open_circles=False,
         If returnfig==False, the figure and its one axis are returned, and can be
         further edited.
     """
-    fig,ax = show(ar,returnfig=True,**kwargs)
+    fig,ax = show(ar,title = title, returnfig=True,**kwargs)
     d = {'x':x,'y':y,'s':s,'scale':scale,'pointcolor':pointcolor,'alpha':alpha,
          'open_circles':open_circles}
     add_points(ax,d)

--- a/py4DSTEM/visualize/vis_grid.py
+++ b/py4DSTEM/visualize/vis_grid.py
@@ -89,9 +89,22 @@ def _show_grid_overlay(image,x0,y0,xL,yL,color='k',linewidth=1,alpha=1,
     else:
         return fig,ax
 
-def show_image_grid(get_ar,H,W,axsize=(6,6),returnfig=False,titlesize=0,
-                    get_bordercolor=None,get_x=None,get_y=None,get_pointcolors=None,
-                    get_s=None,open_circles=False,**kwargs):
+def show_image_grid(
+    get_ar,
+    H,W,
+    axsize=(6,6),
+    returnfig=False,
+    figax = None, 
+    title = None,
+    title_index = False,
+    suptitle = None,
+    get_bordercolor=None,
+    get_x=None,
+    get_y=None,
+    get_pointcolors=None,
+    get_s=None,
+    open_circles=False,
+    **kwargs):
     """
     Displays a set of images in a grid.
 
@@ -114,8 +127,16 @@ def show_image_grid(get_ar,H,W,axsize=(6,6),returnfig=False,titlesize=0,
                     the integers 0 through HW-1
         H,W         integers, the dimensions of the grid
         axsize      the size of each image
-        titlesize   if >0, prints the index i passed to get_ar over
-                    each image
+        figax       controls which matplotlib Axes object draws the image.
+                    If None, generates a new figure with a single Axes instance. 
+                    Otherwise, ax must be a 2-tuple containing the matplotlib class instances 
+                    (Figure,Axes), with ar then plotted in the specified Axes instance.
+        title       if title is sting, then prints title as suptitle. If a suptitle is also provided, 
+                    the suptitle is printed insead.
+                    if title is a list of strings (ex: ['title 1','title 2']), each ar has corresponding 
+                    title in list.
+        title_index if True, prints the index i passed to get_ar over each image 
+        suptitle    string, suptitle on plot
         get_bordercolor
                     if not None, should be a function defined over
                     the same i as get_ar, and which returns a
@@ -142,7 +163,12 @@ def show_image_grid(get_ar,H,W,axsize=(6,6),returnfig=False,titlesize=0,
     _get_points = (get_x is not None) and (get_y is not None)
     _get_colors = get_pointcolors is not None
     _get_s = get_s is not None
-    fig,axs = plt.subplots(H,W,figsize=(W*axsize[0],H*axsize[1]))
+    
+    if figax is None:
+        fig,axs = plt.subplots(H,W,figsize=(W*axsize[0],H*axsize[1]))
+    else:
+        fig,axs = figax
+
     if H==1:
         axs = axs[np.newaxis,:]
     elif W==1:
@@ -151,6 +177,17 @@ def show_image_grid(get_ar,H,W,axsize=(6,6),returnfig=False,titlesize=0,
         for j in range(W):
             ax = axs[i,j]
             N = i*W+j
+            
+            if type(title) == list: 
+                print_title = title[N]
+            else:
+                print_title = None
+
+            if title_index: 
+                if print_title is not None: 
+                    print_title = f"{N}. " + print_title
+                else:
+                    print_title = f"{N}." 
             try:
                 ar = get_ar(N)
                 if _get_bordercolor and _get_points:
@@ -162,36 +199,51 @@ def show_image_grid(get_ar,H,W,axsize=(6,6),returnfig=False,titlesize=0,
                         pointcolors='r'
                     if _get_s:
                         s = get_s(N)
-                        _,_ = show_points(ar,figax=(fig,ax),returnfig=True,
-                                          bordercolor=bc,x=x,y=y,s=s,
-                                          pointcolor=pointcolors,
-                                          open_circles=open_circles,**kwargs)
+                        _,_ = show_points(
+                            ar,figax=(fig,ax),
+                            returnfig=True,
+                            bordercolor=bc,
+                            x=x,y=y,s=s,
+                            pointcolor=pointcolors,
+                            open_circles=open_circles,
+                            title = print_title,
+                            **kwargs)
                     else:
-                        _,_ = show_points(ar,figax=(fig,ax),returnfig=True,
-                                          bordercolor=bc,x=x,y=y,
-                                          pointcolor=pointcolors,
-                                          open_circles=open_circles,**kwargs)
+                        _,_ = show_points(
+                            ar,figax=(fig,ax),
+                            returnfig=True,
+                            bordercolor=bc,
+                            x=x,y=y,
+                            pointcolor=pointcolors,
+                            open_circles=open_circles,
+                            title = print_title,
+                            **kwargs)
                 elif _get_bordercolor:
                     bc = get_bordercolor(N)
                     _,_ = show(ar,figax=(fig,ax),returnfig=True,
-                               bordercolor=bc,**kwargs)
+                               bordercolor=bc,title = print_title, **kwargs)
                 elif _get_points:
                     x,y = get_x(N),get_y(N)
                     if _get_colors:
                         pointcolors = get_pointcolors(N)
                     else:
                         pointcolors='r'
-                    _,_ = show_points(ar,figax=(fig,ax),x=x,y=y,returnfig=True,
-                                      pointcolor=pointcolors,
-                                      open_circles=open_circles,**kwargs)
+                    _,_ = show_points(
+                        ar,figax=(fig,ax),x=x,y=y,
+                        returnfig=True,
+                        pointcolor=pointcolors,
+                        open_circles=open_circles,
+                        title = print_title,
+                         **kwargs)
                 else:
-                    _,_ = show(ar,figax=(fig,ax),returnfig=True,**kwargs)
-                if titlesize>0:
-                    ax.set_title(N,fontsize=titlesize)
+                    _,_ = show(ar,figax=(fig,ax),returnfig=True,title = print_title,**kwargs)
             except IndexError:
                 ax.axis('off')
+    if type(title) == str:
+        fig.suptitle(title)
+    if suptitle:
+        fig.suptitle(suptitle)
     plt.tight_layout()
-
     if not returnfig:
         plt.show()
         return

--- a/py4DSTEM/visualize/vis_grid.py
+++ b/py4DSTEM/visualize/vis_grid.py
@@ -133,8 +133,8 @@ def show_image_grid(
                     (Figure,Axes), with ar then plotted in the specified Axes instance.
         title       if title is sting, then prints title as suptitle. If a suptitle is also provided, 
                     the suptitle is printed insead.
-                    if title is a list of strings (ex: ['title 1','title 2']), each ar has corresponding 
-                    title in list.
+                    if title is a list of strings (ex: ['title 1','title 2']), each array has 
+                    corresponding title in list.
         title_index if True, prints the index i passed to get_ar over each image 
         suptitle    string, suptitle on plot
         get_bordercolor

--- a/py4DSTEM/visualize/vis_grid.py
+++ b/py4DSTEM/visualize/vis_grid.py
@@ -168,7 +168,6 @@ def show_image_grid(
         fig,axs = plt.subplots(H,W,figsize=(W*axsize[0],H*axsize[1]))
     else:
         fig,axs = figax
-
     if H==1:
         axs = axs[np.newaxis,:]
     elif W==1:
@@ -177,17 +176,17 @@ def show_image_grid(
         for j in range(W):
             ax = axs[i,j]
             N = i*W+j
-            
+            #make titles
             if type(title) == list: 
                 print_title = title[N]
             else:
                 print_title = None
-
             if title_index: 
                 if print_title is not None: 
                     print_title = f"{N}. " + print_title
                 else:
                     print_title = f"{N}." 
+            #make figures
             try:
                 ar = get_ar(N)
                 if _get_bordercolor and _get_points:
@@ -244,8 +243,8 @@ def show_image_grid(
     if suptitle:
         fig.suptitle(suptitle)
     plt.tight_layout()
+    
     if not returnfig:
-        plt.show()
         return
     else:
         return fig,axs


### PR DESCRIPTION
This PR has: 
(1) a quick fix for strain mapping for when the braggvectors are calibrated
(2) some options for `show_image_grid` to customize a title and return the figure. For example: 
```
fig, ax = plt.subplots(1,2, figsize = (5,3))
py4DSTEM.show(
    [dc.data[0,0], 
     dc.data[0,1]], 
    figax = (fig,ax), 
    title = ['ducks',"more ducks"],
    title_index = True, 
    suptitle = "animals",
    get_bordercolor=lambda i:['red','blue'][i],
)

ax[0].scatter(56,56, s = 160, color = 'lime')
```
![attachment](https://user-images.githubusercontent.com/55254539/215568732-8200368d-7c6a-4ab8-bb74-5a9910c5b181.png)
