### PR TITLE
convert 1/nm in DM to A^-1

### DIFF
--- a/py4DSTEM/io/nonnative/read_dm.py
+++ b/py4DSTEM/io/nonnative/read_dm.py
@@ -91,6 +91,10 @@ def read_dm(
                         Q_pixel_size = (
                             Q_pixel_size / lamda / 1000.0
                         )  # convert mrad to 1/Å
+                elif Q_pixel_units == "1/nm":
+                    Q_pixel_units = "A^-1"
+                    Q_pixel_size /= 10
+                    
                 pixel_size_found = True
             except Exception as err:
                 pass


### PR DESCRIPTION
This is a simple fix for the DM reader that checks if the pixel size is "1/nm" and converts it to "A^-1".