### PR TITLE
tiny tweaks in MS ptycho

### DIFF
--- a/py4DSTEM/process/phase/iterative_multislice_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_multislice_ptychography.py
@@ -882,7 +882,7 @@ class MultislicePtychographicReconstruction(PhaseReconstruction):
                 )
 
             # back-transmit
-            exit_waves *= xp.conj(obj)
+            exit_waves *= xp.conj(obj) / xp.abs(obj)**2
 
             if s > 0:
                 # back-propagate
@@ -1438,13 +1438,12 @@ class MultislicePtychographicReconstruction(PhaseReconstruction):
                 q_highpass,
             )
 
-        if kz_regularization_filter:
+        if identical_slices:
+            current_object = self._object_identical_slices_constraint(current_object)
+        elif kz_regularization_filter:
             current_object = self._object_kz_regularization_constraint(
                 current_object, kz_regularization_gamma
             )
-
-        if identical_slices:
-            current_object = self._object_identical_slices_constraint(current_object)
 
         if self._object_type == "complex":
             current_object = self._object_threshold_constraint(


### PR DESCRIPTION
This is two small changes:
* Use the correct multiplicative inverse for complex numbers in the multislice backpropagation
* Change logic so that in constrained multislice, we apply _either_ identical slices or `kz` filtering, not both.