### PR TITLE
bugfix in virutalimage.py and get_virtual_image speedup

### DIFF
--- a/py4DSTEM/process/virtualimage.py
+++ b/py4DSTEM/process/virtualimage.py
@@ -108,11 +108,12 @@ def get_virtual_image(
 
             # set up a generalized universal function for dask distribution
             def _apply_mask_dask(datacube,mask):
-                virtual_image = np.sum(np.multiply(datacube.data,mask), dtype=np.float64)
-            apply_mask_dask = da.as_gufunc(
+                return np.sum(np.multiply(datacube.data,mask), dtype=np.float64)
+            apply_mask_dask = da.gufunc(
                 _apply_mask_dask,signature='(i,j),(i,j)->()',
                 output_dtypes=np.float64,
                 axes=[(2,3),(0,1),()],
+                allow_rechunk=True,
                 vectorize=True
             )
 

--- a/py4DSTEM/process/virtualimage.py
+++ b/py4DSTEM/process/virtualimage.py
@@ -124,16 +124,7 @@ def get_virtual_image(
         else:
 
             # compute
-            if mask.dtype == 'complex':
-                virtual_image = np.zeros(datacube.Rshape, dtype = 'complex')
-            else:
-                virtual_image = np.zeros(datacube.Rshape)
-            for rx,ry in tqdmnd(
-                datacube.R_Nx,
-                datacube.R_Ny,
-                disable = not verbose,
-            ):
-                virtual_image[rx,ry] = np.sum(datacube.data[rx,ry]*mask)
+            virtual_image = np.sum(datacube.data[:,:,mask], axis=-1)
 
     # with center shifting
     else:
@@ -291,7 +282,7 @@ def make_detector(
                     or diffraction image respectively
 
     Returns:
-        virtual detector in the form of a 2D mask (array)
+        virtual detector in the form of a 2D mask (bool array)
     '''
     g = geometry
 
@@ -342,6 +333,9 @@ def make_detector(
     if mode == 'mask':
         assert type(g) == np.ndarray, '`geometry` type should be `np.ndarray`'
         assert (g.shape == shape), 'mask and diffraction pattern shapes do not match'
+        if g.dtype != bool:
+            print('Mask is not a bool and will be cast to one!')
+            g = g.astype(bool)
         mask = g
     return mask
 


### PR DESCRIPTION
This first fixes a bug in dask I found in `virtualimage`, and then speeds up the case where the center does not need to be shifted by quite a lot.

<img width="826" alt="image" src="https://user-images.githubusercontent.com/9438848/236045636-07a45733-24a5-443d-a881-8d4d809ea795.png">

Two differences - no more tqdm for the virtual image in the case where it doesn't loop (non-shifted center), and user defined masks are converted to the `bool` dtype, as when they were ints, it was blowing up my computer memory and not actually running.


See PDF benchmark
[benchmark.pdf](https://github.com/py4dstem/py4DSTEM/files/11391113/benchmark.pdf)
