### PR TITLE
backtracking in DPC

### DIFF
--- a/py4DSTEM/process/phase/iterative_dpc.py
+++ b/py4DSTEM/process/phase/iterative_dpc.py
@@ -420,9 +420,6 @@ class DPCReconstruction(PhaseReconstruction):
             xp.mean(self._com_x.ravel() ** 2 + self._com_y.ravel() ** 2)
         )
 
-        if new_error > error:
-            step_size /= 2
-
         return obj_dx, obj_dy, new_error, step_size
 
     def _adjoint(
@@ -670,9 +667,7 @@ class DPCReconstruction(PhaseReconstruction):
             self.error = np.inf
             self._step_size = step_size if step_size is not None else 0.5
             self._padded_phase_object = self._padded_phase_object_initial.copy()
-
-        previous_iteration = self._padded_phase_object.copy()
-
+            
         self.error = getattr(self, "error", np.inf)
 
         if step_size is None:
@@ -693,7 +688,9 @@ class DPCReconstruction(PhaseReconstruction):
         ):
             if self._step_size < stopping_criterion:
                 break
-
+                
+            previous_iteration = self._padded_phase_object.copy()
+            
             # forward operator
             com_dx, com_dy, new_error, self._step_size = self._forward(
                 self._padded_phase_object, mask, mask_inv, self.error, self._step_size
@@ -703,10 +700,10 @@ class DPCReconstruction(PhaseReconstruction):
             # before the error rose and continue with the halved step size
             if (new_error > self.error) and backtrack:
                 self._padded_phase_object = previous_iteration
+                self._step_size /= 2
                 print(f"Iteration {a0}, step reduced to {self._step_size}")
                 continue
             self.error = new_error
-            previous_iteration = self._padded_phase_object.copy()
 
             # adjoint operator
             phase_update = self._adjoint(com_dx, com_dy, self._kx_op, self._ky_op)

--- a/py4DSTEM/process/phase/iterative_dpc.py
+++ b/py4DSTEM/process/phase/iterative_dpc.py
@@ -624,6 +624,10 @@ class DPCReconstruction(PhaseReconstruction):
             Reconstruction update step size
         stopping_criterion: float, optional
             step_size below which reconstruction exits
+        backtrack: bool, optional
+            If True, steps that increase the error metric are rejected
+            and iteration continues with a reduced step size from the
+            previous iteration
         progress_bar: bool, optional
             If True, reconstruction progress bar will be printed
         gaussian_filter_sigma: float, optional

--- a/py4DSTEM/process/phase/iterative_dpc.py
+++ b/py4DSTEM/process/phase/iterative_dpc.py
@@ -602,6 +602,7 @@ class DPCReconstruction(PhaseReconstruction):
         max_iter: int = 64,
         step_size: float = None,
         stopping_criterion: float = 1e-6,
+        backtrack: bool = True,
         progress_bar: bool = True,
         gaussian_filter_sigma: float = None,
         gaussian_filter_iter: int = np.inf,
@@ -666,6 +667,8 @@ class DPCReconstruction(PhaseReconstruction):
             self._step_size = step_size if step_size is not None else 0.5
             self._padded_phase_object = self._padded_phase_object_initial.copy()
 
+        previous_iteration = self._padded_phase_object.copy()
+
         self.error = getattr(self, "error", np.inf)
 
         if step_size is None:
@@ -688,9 +691,18 @@ class DPCReconstruction(PhaseReconstruction):
                 break
 
             # forward operator
-            com_dx, com_dy, self.error, self._step_size = self._forward(
+            com_dx, com_dy, new_error, self._step_size = self._forward(
                 self._padded_phase_object, mask, mask_inv, self.error, self._step_size
             )
+
+            # if the error went up after the previous step, go back to the step
+            # before the error rose and continue with the halved step size
+            if (new_error > self.error) and backtrack:
+                self._padded_phase_object = previous_iteration
+                print(f"Iteration {a0}, step reduced to {self._step_size}")
+                continue
+            self.error = new_error
+            previous_iteration = self._padded_phase_object.copy()
 
             # adjoint operator
             phase_update = self._adjoint(com_dx, com_dy, self._kx_op, self._ky_op)


### PR DESCRIPTION
This adds a simple backtracking step to the iterative DPC, which rejects steps that increase the error. 