### PR TITLE
Gdrive hotfix

### DIFF
--- a/py4DSTEM/io/google_drive_downloader.py
+++ b/py4DSTEM/io/google_drive_downloader.py
@@ -257,7 +257,7 @@ def gdrive_download(
                 # making http/https agnostic
                 elif 'drive.google.com/file/d/' in id_:
                     # warn the user the the url syntax was incorrect and this is making a guess
-                    warnings.warn('URL provided was not provided in the correct format https://drive.google.com/uc?id=<id>, attempting to interpret link and download the file. Most likely a URL format as this was provided in this format https://drive.google.com/file/d/<id>')
+                    warnings.warn('URL provided was not provided in the correct format https://drive.google.com/uc?id=<id>, attempting to interpret link and download the file. Most likely a URL with this format was provided https://drive.google.com/file/d/<id>')
                     # try stripping 
                     stripped_id = id_.split('/')[-1]
                     # Currently the length of the google drive IDs appears to always be 33 characters 

--- a/py4DSTEM/io/google_drive_downloader.py
+++ b/py4DSTEM/io/google_drive_downloader.py
@@ -238,9 +238,16 @@ def gdrive_download(
             f = file_ids[id_]
             filename = f[0]
             kwargs['id'] = f[1]
+        
+        # if its not in the list of files we expect
         else:
             filename = 'gdrivedownload.file' if filename is None else filename
-            kwargs['url'] = id_
+            # check if its a url
+            if id_.startswith('http')
+                kwargs['url'] = id_
+            # if its just a Google Drive string
+            else:
+                kwargs['id'] = id_
 
         # download
         kwargs['output'] = os.path.join(destination, filename)

--- a/py4DSTEM/io/google_drive_downloader.py
+++ b/py4DSTEM/io/google_drive_downloader.py
@@ -1,5 +1,6 @@
 import gdown
 import os
+import warnings
 
 
 ### File IDs
@@ -240,11 +241,30 @@ def gdrive_download(
             kwargs['id'] = f[1]
         
         # if its not in the list of files we expect
+        
+        #TODO simplify the logic here
         else:
             filename = 'gdrivedownload.file' if filename is None else filename
             # check if its a url
             if id_.startswith('http'):
-                kwargs['url'] = id_
+
+                # check the url is the correct format i.e. https://drive.google.com/uc?id=<id>
+                # and not https://drive.google.com/file/d/<id>
+                # if correct format
+                if 'uc?id=' in id_:
+                    kwargs['url'] = id_
+                # if incorrect format, strip the google ID from the URL 
+                # making http/https agnostic
+                elif 'drive.google.com/file/d/' in id_:
+                    # warn the user the the url syntax was incorrect and this is making a guess
+                    warnings.warn('URL provided was not provided in the correct format https://drive.google.com/uc?id=<id>, attempting to interpret link and download the file. Most likely a URL format as this was provided in this format https://drive.google.com/file/d/<id>')
+                    # try stripping 
+                    stripped_id = id_.split('/')[-1]
+                    # Currently the length of the google drive IDs appears to always be 33 characters 
+                    # check for length and warn if it appears malformed, if so raise warning and the ID it guessed
+                    if len(stripped_id) != 33:
+                        warnings.warn(f'Guessed ID {stripped_id}: appears to be in the wrong length (not 33 characters), attempting download')
+                    kwargs['id'] = stripped_id
             # if its just a Google Drive string
             else:
                 kwargs['id'] = id_

--- a/py4DSTEM/io/google_drive_downloader.py
+++ b/py4DSTEM/io/google_drive_downloader.py
@@ -247,7 +247,6 @@ def gdrive_download(
             filename = 'gdrivedownload.file' if filename is None else filename
             # check if its a url
             if id_.startswith('http'):
-
                 # check the url is the correct format i.e. https://drive.google.com/uc?id=<id>
                 # and not https://drive.google.com/file/d/<id>
                 # if correct format
@@ -257,7 +256,7 @@ def gdrive_download(
                 # making http/https agnostic
                 elif 'drive.google.com/file/d/' in id_:
                     # warn the user the the url syntax was incorrect and this is making a guess
-                    warnings.warn('URL provided was not provided in the correct format https://drive.google.com/uc?id=<id>, attempting to interpret link and download the file. Most likely a URL with this format was provided https://drive.google.com/file/d/<id>')
+                    warnings.warn(f'URL provided {id_} was not in the correct format https://drive.google.com/uc?id=<id>, attempting to interpret link and download the file. Most likely a URL with this format was provided https://drive.google.com/file/d/<id>')
                     # try stripping 
                     stripped_id = id_.split('/')[-1]
                     # Currently the length of the google drive IDs appears to always be 33 characters 

--- a/py4DSTEM/io/google_drive_downloader.py
+++ b/py4DSTEM/io/google_drive_downloader.py
@@ -243,7 +243,7 @@ def gdrive_download(
         else:
             filename = 'gdrivedownload.file' if filename is None else filename
             # check if its a url
-            if id_.startswith('http')
+            if id_.startswith('http'):
                 kwargs['url'] = id_
             # if its just a Google Drive string
             else:


### PR DESCRIPTION
Quick fix for `py4DSTEM.io.gdrive_download`, that allows passing just the google drive id to the function and passing to `gdown.download correctly`

example that works
```
id_ = '1AWB3-UTPiTR9dgrEkNFD7EJYsKnbEy0y'
py4DSTEM.io.gdrive_download(
    id_= id_,
    destination = '/content/',
    filename = 'polycrystal_2D_WS2.h5',  
)
```