### PR TITLE
Whole pattern fitting

### DIFF
--- a/py4DSTEM/process/wholepatternfit/wp_models.py
+++ b/py4DSTEM/process/wholepatternfit/wp_models.py
@@ -583,7 +583,9 @@ class SyntheticDiskLattice(WPFModel):
 
             mask = r_disk < (2 * disk_radius)
 
-            top_exp = mask * np.exp(4 * ((mask * r_disk) - disk_radius) / disk_width)
+            top_exp = mask * np.exp(
+                np.minimum(30, 4 * ((mask * r_disk) - disk_radius) / disk_width)
+            )
 
             # dF/d(x0)
             dx = (
@@ -730,7 +732,9 @@ class SyntheticDiskMoire(WPFModel):
             )
             ** 2
         )
-        tests = tests[np.abs(a_dot_b) < 0.9] # this factor of 0.9 sets the parallel cutoff
+        tests = tests[
+            np.abs(a_dot_b) < 0.9
+        ]  # this factor of 0.9 sets the parallel cutoff
         # with the parallel vectors filtered, pick the cell with the smallest volume
         lat_m = tests @ lat_ab
         V = np.sum(
@@ -1037,7 +1041,10 @@ class SyntheticDiskMoire(WPFModel):
 
             mask = r_disk < (2 * disk_radius)
 
-            top_exp = mask * np.exp(4 * ((mask * r_disk) - disk_radius) / disk_width)
+            # clamp the argument of the exponent at a very large finite value
+            top_exp = mask * np.exp(
+                np.minimum(30, 4 * ((mask * r_disk) - disk_radius) / disk_width)
+            )
 
             # dF/d(x0)
             dx = (

--- a/py4DSTEM/process/wholepatternfit/wpf.py
+++ b/py4DSTEM/process/wholepatternfit/wpf.py
@@ -466,7 +466,7 @@ class WholePatternFit:
                     self.fit_data.data[lat.params["uy"].offset],
                     self.fit_data.data[lat.params["vx"].offset],
                     self.fit_data.data[lat.params["vy"].offset],
-                    np.ones(self.fit_data.data.shape[1:], dtype=np.bool_),
+                    self.fit_metrics["status"] >= 0, # negative status indicates fit error
                 ],
                 axis=0,
             )

--- a/py4DSTEM/process/wholepatternfit/wpf.py
+++ b/py4DSTEM/process/wholepatternfit/wpf.py
@@ -406,7 +406,7 @@ class WholePatternFit:
                     except Exception as err:
                         # print(err)
                         fit_data_single = x0
-                        fit_metrics_single = [0, 0, 0, 0]
+                        fit_metrics_single = [0, 0, 0, -2]
 
                     fit_data[:, rx, ry] = fit_data_single
                     fit_metrics[:, rx, ry] = fit_metrics_single
@@ -639,7 +639,7 @@ class WholePatternFit:
             except Exception as err:
                 # print(err)
                 fit_coefs = initial_guess
-                fit_metrics_single = [0, 0, 0, 0]
+                fit_metrics_single = [0, 0, 0, -2]
 
             return fit_coefs, fit_metrics_single
         else:

--- a/py4DSTEM/process/wholepatternfit/wpf.py
+++ b/py4DSTEM/process/wholepatternfit/wpf.py
@@ -466,7 +466,7 @@ class WholePatternFit:
                     self.fit_data.data[lat.params["uy"].offset],
                     self.fit_data.data[lat.params["vx"].offset],
                     self.fit_data.data[lat.params["vy"].offset],
-                    self.fit_metrics["status"] >= 0, # negative status indicates fit error
+                    self.fit_metrics["status"].data >= 0, # negative status indicates fit error
                 ],
                 axis=0,
             )

--- a/py4DSTEM/process/wholepatternfit/wpf.py
+++ b/py4DSTEM/process/wholepatternfit/wpf.py
@@ -404,7 +404,6 @@ class WholePatternFit:
                             opt.status,
                         ]
                     except Exception as err:
-                        # print(err)
                         fit_data_single = x0
                         fit_metrics_single = [0, 0, 0, -2]
 

--- a/py4DSTEM/process/wholepatternfit/wpf_viz.py
+++ b/py4DSTEM/process/wholepatternfit/wpf_viz.py
@@ -222,6 +222,7 @@ def show_fit_metrics(self, returnfig=False, **subplots_kwargs):
 
     opt_cmap = mpl_c.ListedColormap(
         (
+            (0.6, 0.05, 0.05),
             (0.8941176470588236, 0.10196078431372549, 0.10980392156862745),
             (0.21568627450980393, 0.49411764705882355, 0.7215686274509804),
             (0.30196078431372547, 0.6862745098039216, 0.2901960784313726),
@@ -231,11 +232,12 @@ def show_fit_metrics(self, returnfig=False, **subplots_kwargs):
         )
     )
     im = ax[0, 1].matshow(
-        self.fit_metrics["status"].data, cmap=opt_cmap, vmin=-1.5, vmax=4.5
+        self.fit_metrics["status"].data, cmap=opt_cmap, vmin=-2.5, vmax=4.5
     )
-    cbar = fig.colorbar(im, ax=ax[0, 1], ticks=[-1, 0, 1, 2, 3, 4])
+    cbar = fig.colorbar(im, ax=ax[0, 1], ticks=[-2, -1, 0, 1, 2, 3, 4])
     cbar.ax.set_yticklabels(
         [
+            "Unknown Error",
             "MINPACK Error",
             "Max f evals exceeded",
             "$gtol$ satisfied",


### PR DESCRIPTION
This adds some minor updates to the previous WPF PR
* Clamp some values to prevent numerical overflow
* Add a generic error state to the fit metric to indicate pixels where `least_squares` raised an exception.
* Use the error state as the mask for strain maps. 