### PR TITLE
Py39 fix

### DIFF
--- a/.github/workflows/check_install_dev.yml
+++ b/.github/workflows/check_install_dev.yml
@@ -16,7 +16,7 @@ jobs:
                 allow_failure: [false]
                 runs-on: [ubuntu-latest]
                 architecture: [x86_64]
-                python-version: ["3.10", "3.11",]
+                python-version: ["3.9", "3.10", "3.11",]
                 # Currently no public runners available for this but this or arm64 should work next time
                 # include:
                 #     - python-version: "3.10"

--- a/.github/workflows/check_install_main.yml
+++ b/.github/workflows/check_install_main.yml
@@ -16,7 +16,7 @@ jobs:
                 allow_failure: [false]
                 runs-on: [ubuntu-latest, windows-latest, macos-latest]
                 architecture: [x86_64]
-                python-version: ["3.10", "3.11",]
+                python-version: ["3.9", "3.10", "3.11",]
                 include:
                     - python-version: "3.12.0-beta.4"
                       runs-on: ubuntu-latest

--- a/py4DSTEM/process/wholepatternfit/wpf.py
+++ b/py4DSTEM/process/wholepatternfit/wpf.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from py4DSTEM import DataCube, RealSlice
 from emdfile import tqdmnd
 from py4DSTEM.process.wholepatternfit.wp_models import (

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author_email="ben.savitzky@gmail.com",
     license="GNU GPLv3",
     keywords="STEM 4DSTEM",
-    python_requires=">=3.10,<3.12",
+    python_requires=">=3.9,<3.12",
     install_requires=[
         "numpy >= 1.19",
         "scipy >= 1.5.2",


### PR DESCRIPTION
adding back python 3.9 compatability, by using `from __future__ import annotations` in `wpf.py`, which has made it install with python 3.9 environment. I haven't run other tests, maybe @Steve could double-check? 