### PR TITLE
impose lower bound on cupy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
             "tensorflow == 2.4.1",
             "tensorflow-addons <= 0.14.0",
             "crystal4D",
-            "cupy",
+            "cupy >= 10.0.0",
         ],
         "numba": ["numba >= 0.49.1"],
     },


### PR DESCRIPTION
If you are running
`pip install "py4dstem[aiml-cuda]"`
It doesn’t require any specific version of cupy.

On the other hand if you are just doing 
`pip install "py4dstem[cuda]"`
 it will require above 10.0.0.

This should be tested to see if AI/ML packages will work with `cupy => 10`.  @alex-rakowski 
