### PR TITLE
BraggVects append fix

### DIFF
--- a/py4DSTEM/braggvectors/braggvectors.py
+++ b/py4DSTEM/braggvectors/braggvectors.py
@@ -285,6 +285,7 @@ class BraggVectors(Custom, BraggVectorMethods, Data):
         md["Qshape"] = self.Qshape
         self.metadata = md
         grp = Custom.to_h5(self, group)
+        return grp
 
     # read
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "gdown >= 4.7.1",
         "dask >= 2.3.0",
         "distributed >= 2.3.0",
-        "emdfile >= 0.0.12",
+        "emdfile >= 0.0.13",
         "mpire >= 2.7.1",
         "threadpoolctl >= 3.1.0",
     ],


### PR DESCRIPTION
Fixes a bug in which saving in "appendover" mode failed for Custom type objects, like BraggVectors.

Note to devs! @smribet @sezelt @alex-rakowski @cophus @gvarnavi:
This PR bumps the `emdfile` version, which is required for good behavior.  *Most likely* this will not cause any issues in your dev environments after merging/pulling on this code, however, if it does, re-run `pip install -e .` to update emdfile. 