### PR TITLE
turning off black formatter for __innit__.py files 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,61 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/miniconda
+{
+	"name": "py4dstem-dev",
+	"image": "mcr.microsoft.com/vscode/devcontainers/miniconda:0-3",
+	// "build": { 
+	// 	"context": "..",
+	// 	"dockerfile": "Dockerfile"
+	// },
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": []
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "/opt/conda/bin/conda init && /opt/conda/bin/pip install -e /workspaces/py4DSTEM/ && /opt/conda/bin/pip install ipython ipykernel jupyter",
+	
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"python.defaultInterpreterPath": "/opt/conda/bin/python",
+				"python.analysis.autoFormatStrings": true,
+				"python.analysis.completeFunctionParens": true,
+				"ruff.showNotifications": "onWarning",
+				"workbench.colorTheme": "Monokai",
+				// "editor.defaultFormatter": "ms-python.black-formatter",
+				"editor.fontFamily": "Menlo, Monaco, 'Courier New', monospace",
+				"editor.bracketPairColorization.enabled": true,
+				"editor.guides.bracketPairs": "active",
+				"editor.minimap.renderCharacters": false,
+				"editor.minimap.autohide": true,
+				"editor.minimap.scale": 2,
+				"[python]": {
+					"editor.defaultFormatter": "ms-python.black-formatter",
+					"editor.codeActionsOnSave": {
+						"source.organizeImports": false
+					}
+				}
+			},
+			"extensions": [
+				"ms-python.python",
+				"donjayamanne.python-extension-pack",
+				"ms-python.vscode-pylance",
+				"ms-toolsai.jupyter",
+				"GitHub.codespaces",
+				"ms-azuretools.vscode-docker",
+				"DavidAnson.vscode-markdownlint",
+                "ms-vsliveshare.vsliveshare",
+				"charliermarsh.ruff",
+				"eamodio.gitlens",
+				"ms-python.black-formatter"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/py4DSTEM/__init__.py
+++ b/py4DSTEM/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.version import __version__
 from emdfile import tqdmnd
 

--- a/py4DSTEM/__init__.py
+++ b/py4DSTEM/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.version import __version__
 from emdfile import tqdmnd
 

--- a/py4DSTEM/braggvectors/__init__.py
+++ b/py4DSTEM/braggvectors/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.braggvectors.probe import Probe
 from py4DSTEM.braggvectors.braggvectors import BraggVectors
 from py4DSTEM.braggvectors.braggvector_methods import BraggVectorMap

--- a/py4DSTEM/braggvectors/__init__.py
+++ b/py4DSTEM/braggvectors/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.braggvectors.probe import Probe
 from py4DSTEM.braggvectors.braggvectors import BraggVectors
 from py4DSTEM.braggvectors.braggvector_methods import BraggVectorMap

--- a/py4DSTEM/data/__init__.py
+++ b/py4DSTEM/data/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 _emd_hook = True
 
 from py4DSTEM.data.calibration import Calibration

--- a/py4DSTEM/data/__init__.py
+++ b/py4DSTEM/data/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 _emd_hook = True
 
 from py4DSTEM.data.calibration import Calibration

--- a/py4DSTEM/datacube/__init__.py
+++ b/py4DSTEM/datacube/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 _emd_hook = True
 
 from py4DSTEM.datacube.datacube import DataCube

--- a/py4DSTEM/datacube/__init__.py
+++ b/py4DSTEM/datacube/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 _emd_hook = True
 
 from py4DSTEM.datacube.datacube import DataCube

--- a/py4DSTEM/io/__init__.py
+++ b/py4DSTEM/io/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 # read / write
 from py4DSTEM.io.importfile import import_file
 from py4DSTEM.io.read import read

--- a/py4DSTEM/io/__init__.py
+++ b/py4DSTEM/io/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 # read / write
 from py4DSTEM.io.importfile import import_file
 from py4DSTEM.io.read import read

--- a/py4DSTEM/io/filereaders/__init__.py
+++ b/py4DSTEM/io/filereaders/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.io.filereaders.read_dm import read_dm
 from py4DSTEM.io.filereaders.read_K2 import read_gatan_K2_bin
 from py4DSTEM.io.filereaders.empad import read_empad

--- a/py4DSTEM/io/filereaders/__init__.py
+++ b/py4DSTEM/io/filereaders/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.io.filereaders.read_dm import read_dm
 from py4DSTEM.io.filereaders.read_K2 import read_gatan_K2_bin
 from py4DSTEM.io.filereaders.empad import read_empad

--- a/py4DSTEM/io/legacy/__init__.py
+++ b/py4DSTEM/io/legacy/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.io.legacy.read_legacy_13 import *
 from py4DSTEM.io.legacy.read_legacy_12 import *
 from py4DSTEM.io.legacy.read_utils import *

--- a/py4DSTEM/io/legacy/__init__.py
+++ b/py4DSTEM/io/legacy/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.io.legacy.read_legacy_13 import *
 from py4DSTEM.io.legacy.read_legacy_12 import *
 from py4DSTEM.io.legacy.read_utils import *

--- a/py4DSTEM/io/legacy/legacy12/__init__.py
+++ b/py4DSTEM/io/legacy/legacy12/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from .read_v0_5 import read_v0_5
 from .read_v0_6 import read_v0_6
 from .read_v0_7 import read_v0_7

--- a/py4DSTEM/io/legacy/legacy12/__init__.py
+++ b/py4DSTEM/io/legacy/legacy12/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from .read_v0_5 import read_v0_5
 from .read_v0_6 import read_v0_6
 from .read_v0_7 import read_v0_7

--- a/py4DSTEM/io/legacy/legacy13/__init__.py
+++ b/py4DSTEM/io/legacy/legacy13/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from .v13_emd_classes import Root, Metadata, Array, PointList, PointListArray
 from .v13_py4dstem_classes import (
     Calibration,

--- a/py4DSTEM/io/legacy/legacy13/__init__.py
+++ b/py4DSTEM/io/legacy/legacy13/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from .v13_emd_classes import Root, Metadata, Array, PointList, PointListArray
 from .v13_py4dstem_classes import (
     Calibration,

--- a/py4DSTEM/io/legacy/legacy13/v13_emd_classes/__init__.py
+++ b/py4DSTEM/io/legacy/legacy13/v13_emd_classes/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.io.legacy.legacy13.v13_emd_classes.tree import *
 from py4DSTEM.io.legacy.legacy13.v13_emd_classes.root import *
 from py4DSTEM.io.legacy.legacy13.v13_emd_classes.metadata import *

--- a/py4DSTEM/io/legacy/legacy13/v13_emd_classes/__init__.py
+++ b/py4DSTEM/io/legacy/legacy13/v13_emd_classes/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.io.legacy.legacy13.v13_emd_classes.tree import *
 from py4DSTEM.io.legacy.legacy13.v13_emd_classes.root import *
 from py4DSTEM.io.legacy.legacy13.v13_emd_classes.metadata import *

--- a/py4DSTEM/io/legacy/legacy13/v13_py4dstem_classes/__init__.py
+++ b/py4DSTEM/io/legacy/legacy13/v13_py4dstem_classes/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.io.legacy.legacy13.v13_py4dstem_classes.calibration import *
 from py4DSTEM.io.legacy.legacy13.v13_py4dstem_classes.datacube import *
 from py4DSTEM.io.legacy.legacy13.v13_py4dstem_classes.probe import *

--- a/py4DSTEM/io/legacy/legacy13/v13_py4dstem_classes/__init__.py
+++ b/py4DSTEM/io/legacy/legacy13/v13_py4dstem_classes/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.io.legacy.legacy13.v13_py4dstem_classes.calibration import *
 from py4DSTEM.io.legacy.legacy13.v13_py4dstem_classes.datacube import *
 from py4DSTEM.io.legacy.legacy13.v13_py4dstem_classes.probe import *

--- a/py4DSTEM/preprocess/__init__.py
+++ b/py4DSTEM/preprocess/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.preprocess.utils import *
 from py4DSTEM.preprocess.preprocess import *
 from py4DSTEM.preprocess.darkreference import *

--- a/py4DSTEM/preprocess/__init__.py
+++ b/py4DSTEM/preprocess/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.preprocess.utils import *
 from py4DSTEM.preprocess.preprocess import *
 from py4DSTEM.preprocess.darkreference import *

--- a/py4DSTEM/process/__init__.py
+++ b/py4DSTEM/process/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.process.polar import PolarDatacube
 from py4DSTEM.process.strain import StrainMap
 

--- a/py4DSTEM/process/__init__.py
+++ b/py4DSTEM/process/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.process.polar import PolarDatacube
 from py4DSTEM.process.strain import StrainMap
 

--- a/py4DSTEM/process/calibration/__init__.py
+++ b/py4DSTEM/process/calibration/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.process.calibration.qpixelsize import *
 from py4DSTEM.process.calibration.origin import *
 from py4DSTEM.process.calibration.ellipse import *

--- a/py4DSTEM/process/calibration/__init__.py
+++ b/py4DSTEM/process/calibration/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.process.calibration.qpixelsize import *
 from py4DSTEM.process.calibration.origin import *
 from py4DSTEM.process.calibration.ellipse import *

--- a/py4DSTEM/process/classification/__init__.py
+++ b/py4DSTEM/process/classification/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.process.classification.braggvectorclassification import *
 from py4DSTEM.process.classification.classutils import *
 from py4DSTEM.process.classification.featurization import *

--- a/py4DSTEM/process/classification/__init__.py
+++ b/py4DSTEM/process/classification/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.process.classification.braggvectorclassification import *
 from py4DSTEM.process.classification.classutils import *
 from py4DSTEM.process.classification.featurization import *

--- a/py4DSTEM/process/diffraction/__init__.py
+++ b/py4DSTEM/process/diffraction/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.process.diffraction.crystal import *
 from py4DSTEM.process.diffraction.flowlines import *
 from py4DSTEM.process.diffraction.tdesign import *

--- a/py4DSTEM/process/diffraction/__init__.py
+++ b/py4DSTEM/process/diffraction/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.process.diffraction.crystal import *
 from py4DSTEM.process.diffraction.flowlines import *
 from py4DSTEM.process.diffraction.tdesign import *

--- a/py4DSTEM/process/fit/__init__.py
+++ b/py4DSTEM/process/fit/__init__.py
@@ -1,2 +1,2 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.process.fit.fit import *

--- a/py4DSTEM/process/fit/__init__.py
+++ b/py4DSTEM/process/fit/__init__.py
@@ -1,1 +1,2 @@
+#fmt: off
 from py4DSTEM.process.fit.fit import *

--- a/py4DSTEM/process/latticevectors/__init__.py
+++ b/py4DSTEM/process/latticevectors/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.process.latticevectors.initialguess import *
 from py4DSTEM.process.latticevectors.index import *
 from py4DSTEM.process.latticevectors.fit import *

--- a/py4DSTEM/process/latticevectors/__init__.py
+++ b/py4DSTEM/process/latticevectors/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.process.latticevectors.initialguess import *
 from py4DSTEM.process.latticevectors.index import *
 from py4DSTEM.process.latticevectors.fit import *

--- a/py4DSTEM/process/phase/__init__.py
+++ b/py4DSTEM/process/phase/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 # fmt: off
 
 _emd_hook = True

--- a/py4DSTEM/process/phase/__init__.py
+++ b/py4DSTEM/process/phase/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 # fmt: off
 
 _emd_hook = True

--- a/py4DSTEM/process/polar/__init__.py
+++ b/py4DSTEM/process/polar/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.process.polar.polar_datacube import PolarDatacube
 from py4DSTEM.process.polar.polar_fits import fit_amorphous_ring, plot_amorphous_ring
 from py4DSTEM.process.polar.polar_peaks import (

--- a/py4DSTEM/process/polar/__init__.py
+++ b/py4DSTEM/process/polar/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.process.polar.polar_datacube import PolarDatacube
 from py4DSTEM.process.polar.polar_fits import fit_amorphous_ring, plot_amorphous_ring
 from py4DSTEM.process.polar.polar_peaks import (

--- a/py4DSTEM/process/rdf/__init__.py
+++ b/py4DSTEM/process/rdf/__init__.py
@@ -1,1 +1,2 @@
+#fmt: off
 from py4DSTEM.process.rdf.rdf import *

--- a/py4DSTEM/process/rdf/__init__.py
+++ b/py4DSTEM/process/rdf/__init__.py
@@ -1,2 +1,2 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.process.rdf.rdf import *

--- a/py4DSTEM/process/utils/__init__.py
+++ b/py4DSTEM/process/utils/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.process.utils.utils import *
 from py4DSTEM.process.utils.cross_correlate import *
 from py4DSTEM.process.utils.multicorr import *

--- a/py4DSTEM/process/utils/__init__.py
+++ b/py4DSTEM/process/utils/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.process.utils.utils import *
 from py4DSTEM.process.utils.cross_correlate import *
 from py4DSTEM.process.utils.multicorr import *

--- a/py4DSTEM/process/wholepatternfit/__init__.py
+++ b/py4DSTEM/process/wholepatternfit/__init__.py
@@ -1,3 +1,3 @@
-#fmt: off
+# fmt: off
 from .wp_models import *
 from .wpf import *

--- a/py4DSTEM/process/wholepatternfit/__init__.py
+++ b/py4DSTEM/process/wholepatternfit/__init__.py
@@ -1,2 +1,3 @@
+#fmt: off
 from .wp_models import *
 from .wpf import *

--- a/py4DSTEM/utils/__init__.py
+++ b/py4DSTEM/utils/__init__.py
@@ -1,2 +1,2 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.utils.configuration_checker import check_config

--- a/py4DSTEM/utils/__init__.py
+++ b/py4DSTEM/utils/__init__.py
@@ -1,1 +1,2 @@
+#fmt: off
 from py4DSTEM.utils.configuration_checker import check_config

--- a/py4DSTEM/visualize/__init__.py
+++ b/py4DSTEM/visualize/__init__.py
@@ -1,3 +1,4 @@
+#fmt: off
 from py4DSTEM.visualize.overlay import *
 from py4DSTEM.visualize.show import *
 from py4DSTEM.visualize.vis_RQ import *

--- a/py4DSTEM/visualize/__init__.py
+++ b/py4DSTEM/visualize/__init__.py
@@ -1,4 +1,4 @@
-#fmt: off
+# fmt: off
 from py4DSTEM.visualize.overlay import *
 from py4DSTEM.visualize.show import *
 from py4DSTEM.visualize.vis_RQ import *


### PR DESCRIPTION
added `#fmt:off` to the start of all ` __init__.py` files, so black doesn't won't run on them. 

Used this script below to achieve it. 

```
import os

def add_fmt_off_to_init_py_files():
    for root, directories, files in os.walk('.'):
        for filename in files:
            if filename == '__init__.py':
                with open(os.path.join(root, filename), 'r+') as f:
                    content = f.read()
                    f.seek(0)
                    f.write('#fmt: off\n' + content)
                    f.truncate()

if __name__ == '__main__':
    add_fmt_off_to_init_py_files()
```