### PR TITLE
disk detect CUDA+distributed bugfix

### DIFF
--- a/py4DSTEM/braggvectors/diskdetection.py
+++ b/py4DSTEM/braggvectors/diskdetection.py
@@ -555,6 +555,8 @@ def _find_Bragg_disks_CUDA_unbatched(
     # Populate a BraggVectors instance and return
     braggvectors = BraggVectors(datacube.Rshape, datacube.Qshape)
     braggvectors._v_uncal = peaks
+    braggvectors._set_raw_vector_getter()
+    braggvectors._set_cal_vector_getter()
     return braggvectors
 
 
@@ -600,6 +602,8 @@ def _find_Bragg_disks_CUDA_batched(
     # Populate a BraggVectors instance and return
     braggvectors = BraggVectors(datacube.Rshape, datacube.Qshape)
     braggvectors._v_uncal = peaks
+    braggvectors._set_raw_vector_getter()
+    braggvectors._set_cal_vector_getter()
     return braggvectors
 
 
@@ -650,6 +654,8 @@ def _find_Bragg_disks_ipp(
     # Populate a BraggVectors instance and return
     braggvectors = BraggVectors(datacube.Rshape, datacube.Qshape)
     braggvectors._v_uncal = peaks
+    braggvectors._set_raw_vector_getter()
+    braggvectors._set_cal_vector_getter()
     return braggvectors
 
 
@@ -700,6 +706,8 @@ def _find_Bragg_disks_dask(
     # Populate a BraggVectors instance and return
     braggvectors = BraggVectors(datacube.Rshape, datacube.Qshape)
     braggvectors._v_uncal = peaks
+    braggvectors._set_raw_vector_getter()
+    braggvectors._set_cal_vector_getter()
     return braggvectors
 
 

--- a/py4DSTEM/process/wholepatternfit/wpf.py
+++ b/py4DSTEM/process/wholepatternfit/wpf.py
@@ -467,7 +467,8 @@ class WholePatternFit:
                     self.fit_data.data[lat.params["uy"].offset],
                     self.fit_data.data[lat.params["vx"].offset],
                     self.fit_data.data[lat.params["vy"].offset],
-                    self.fit_metrics["status"].data >= 0, # negative status indicates fit error
+                    self.fit_metrics["status"].data
+                    >= 0,  # negative status indicates fit error
                 ],
                 axis=0,
             )


### PR DESCRIPTION
Bugfix to CUDA and distributed disk detection where new braggvectors `.raw` and `.cal` properties were not correctly pointing to their vector data