### PR TITLE
Change how `cupy` import fall-through is handled

### DIFF
--- a/py4DSTEM/braggvectors/diskdetection_aiml_cuda.py
+++ b/py4DSTEM/braggvectors/diskdetection_aiml_cuda.py
@@ -17,8 +17,8 @@ from py4DSTEM.braggvectors.diskdetection_aiml import _get_latest_model
 
 try:
     import cupy as cp
-except:
-    raise ImportError("Import Error: Please install cupy before proceeding")
+except ModuleNotFoundError:
+    raise ImportError("AIML CUDA Requires cupy")
 
 try:
     import tensorflow as tf

--- a/py4DSTEM/preprocess/utils.py
+++ b/py4DSTEM/preprocess/utils.py
@@ -5,8 +5,8 @@ from scipy.ndimage import gaussian_filter
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 
 def bin2D(array, factor, dtype=np.float64):

--- a/py4DSTEM/process/phase/iterative_base_class.py
+++ b/py4DSTEM/process/phase/iterative_base_class.py
@@ -13,8 +13,8 @@ from scipy.ndimage import rotate
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 from emdfile import Array, Custom, Metadata, _read_metadata, tqdmnd
 from py4DSTEM.data import Calibration

--- a/py4DSTEM/process/phase/iterative_dpc.py
+++ b/py4DSTEM/process/phase/iterative_dpc.py
@@ -13,8 +13,8 @@ from mpl_toolkits.axes_grid1 import ImageGrid, make_axes_locatable
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 from emdfile import Array, Custom, Metadata, _read_metadata, tqdmnd
 from py4DSTEM.data import Calibration

--- a/py4DSTEM/process/phase/iterative_mixedstate_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_mixedstate_ptychography.py
@@ -14,8 +14,8 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg, show_c
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube

--- a/py4DSTEM/process/phase/iterative_multislice_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_multislice_ptychography.py
@@ -14,8 +14,8 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg, show_c
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube

--- a/py4DSTEM/process/phase/iterative_overlap_magnetic_tomography.py
+++ b/py4DSTEM/process/phase/iterative_overlap_magnetic_tomography.py
@@ -16,8 +16,8 @@ from scipy.ndimage import rotate as rotate_np
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube

--- a/py4DSTEM/process/phase/iterative_overlap_tomography.py
+++ b/py4DSTEM/process/phase/iterative_overlap_tomography.py
@@ -16,8 +16,8 @@ from scipy.ndimage import rotate as rotate_np
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube

--- a/py4DSTEM/process/phase/iterative_parallax.py
+++ b/py4DSTEM/process/phase/iterative_parallax.py
@@ -19,8 +19,8 @@ from scipy.special import comb
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 warnings.simplefilter(action="always", category=UserWarning)
 

--- a/py4DSTEM/process/phase/iterative_simultaneous_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_simultaneous_ptychography.py
@@ -14,8 +14,8 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube

--- a/py4DSTEM/process/phase/iterative_singleslice_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_singleslice_ptychography.py
@@ -14,8 +14,8 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 from emdfile import Custom, tqdmnd
 from py4DSTEM.datacube import DataCube

--- a/py4DSTEM/process/utils/cross_correlate.py
+++ b/py4DSTEM/process/utils/cross_correlate.py
@@ -6,8 +6,8 @@ from py4DSTEM.process.utils.multicorr import upsampled_correlation
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 
 def get_cross_correlation(ar, template, corrPower=1, _returnval="real"):

--- a/py4DSTEM/process/utils/multicorr.py
+++ b/py4DSTEM/process/utils/multicorr.py
@@ -15,8 +15,8 @@ import numpy as np
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 
 def upsampled_correlation(imageCorr, upsampleFactor, xyShift, device="cpu"):

--- a/py4DSTEM/process/utils/utils.py
+++ b/py4DSTEM/process/utils/utils.py
@@ -24,8 +24,8 @@ except ImportError:
 
 try:
     import cupy as cp
-except ImportError:
-    cp = None
+except ModuleNotFoundError:
+    cp = np
 
 
 def radial_reduction(ar, x0, y0, binsize=1, fn=np.mean, coords=None):


### PR DESCRIPTION
Currently, we have many instances of this pattern:
```python
try:
    import cupy as cp
except:
    cp = None
```

This is done to ensure that we can write code that mixes usage of `numpy` and `cupy` while still importing in an environment that doesn't have `cupy` installed. Selection between the modules is done through logic within the code (and this is always necessary because even when `cupy` is present it's not optimal to _always_ replace `numpy` with `cupy`). 

This pattern causes two problems:
1. It suppresses *all* errors raised by `import cupy as cp`. On many systems, `cupy` is present but misconfigured, and the errors it emits to warn users of this are caught and dropped by this code. 
2. Setting `cp = None` makes the eventual error that appears in the former scenario extremely confusing (usually something along the lines of `AttributeError: 'NoneType' object has no attribute 'asnumpy'`. This also interferes with static analysis, and causes it to flag any use of `cp` since it (correctly) infers that `cp` can equal either `cupy` or `None`.  

This PR changes these two behaviors by replacing the above pattern with the following:
```python
try:
    import cupy as cp
except ModuleNotFoundError:
    cp = np
```

Issue (1) is addressed by only capturing `ModuleNotFoundError`, so that if `cupy` is present but misconfigured, its import error gets properly raised, and issue (2) is... different. In the case where `cupy` was misconfigured, we will fail much earlier and in a clearer way, so the user never reaches the call to `None.asnumpy`. In the case of the static analyzer, in an environment without `cupy` it will flag only methods that exist in `cupy` but not `numpy`, reducing but not eliminating the false positives. The only oddly behaved case is if a user uses `device='gpu'` in an environment that don't have `cupy` installed at all, in which case they will eventually encounter some `AttributeError` when a `cupy`-only function is called on `numpy`. 

Merging closes #527.