### PR TITLE
Hotfix for matplotlib plotting bug in crystal_viz

### DIFF
--- a/py4DSTEM/process/diffraction/crystal_viz.py
+++ b/py4DSTEM/process/diffraction/crystal_viz.py
@@ -149,7 +149,7 @@ def plot_structure(
             zs=xyz[sub, 2],  # + d[2],
             s=size_marker,
             linewidth=2,
-            color=atomic_colors(ID_plot),
+            facecolors=atomic_colors(ID_plot),
             edgecolor=[0, 0, 0],
         )
 


### PR DESCRIPTION
Fix the new matplotlib scatter behaviour where
colors=atomic_colors(ID_plot),
is no longer valid
