### PR TITLE
Minor addition to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.swp
 *.ipynb_checkpoints*
 .vscode/
+pyrightconfig.json
 
 # Folders #
 .idea/


### PR DESCRIPTION
`pyright` requires a config file in the project directory; this PR adds that file to gitignore. 