### PR TITLE
Quickfix DeprecationWarning

### DIFF
--- a/py4DSTEM/process/diffraction/crystal_viz.py
+++ b/py4DSTEM/process/diffraction/crystal_viz.py
@@ -5,7 +5,7 @@ import matplotlib.tri as mtri
 from mpl_toolkits.mplot3d import Axes3D, art3d
 from scipy.signal import medfilt
 from scipy.ndimage import gaussian_filter
-from scipy.ndimage.morphology import distance_transform_edt
+from scipy.ndimage import distance_transform_edt
 from skimage.morphology import dilation, erosion
 
 import warnings


### PR DESCRIPTION
fixing 
```
DeprecationWarning: Please use `distance_transform_edt` from the `scipy.ndimage` namespace, the `scipy.ndimage.morphology` namespace is deprecated.
    from scipy.ndimage.morphology import distance_transform_edt
```

It's used elsewhere in the code so shouldn't be an issue