### PR TITLE
fixing is to ==

### DIFF
--- a/py4DSTEM/process/calibration/origin.py
+++ b/py4DSTEM/process/calibration/origin.py
@@ -154,7 +154,7 @@ def fit_origin(
                 robust=robust,
                 robust_steps=robust_steps,
                 robust_thresh=robust_thresh,
-                data_mask=mask is True,
+                data_mask=mask == True,  # noqa E712
             )
             popt_y, pcov_y, qy0_fit, _ = fit_2D(
                 f,
@@ -162,7 +162,7 @@ def fit_origin(
                 robust=robust,
                 robust_steps=robust_steps,
                 robust_thresh=robust_thresh,
-                data_mask=mask is True,
+                data_mask=mask == True,  # noqa E712
             )
 
     # Compute residuals


### PR DESCRIPTION
Fixing an bug I introduced. 



tested with:
```
test_ptycho = py4DSTEM.process.phase.SingleslicePtychographicReconstruction(
    datacube=test_dc,
    verbose=False,
    energy=energy,
    semiangle_cutoff=semiangle_cutoff,
    defocus=defocus,
    #device='gpu',
    object_padding_px=(num_detector_pixels//4,)*2,
    object_type='potential',
).preprocess(
    force_com_rotation=0,
    force_com_transpose=False,
    plot_rotation=False,
    plot_center_of_mass = False,
).reconstruct(**reconstruct_params) 
```
and 
```
test_DPC = py4DSTEM.process.phase.DPCReconstruction(
    datacube=test_dc,
    verbose=False,
    energy=energy, 
).preprocess(
    force_com_rotation=0,
    force_com_transpose=False,
    plot_rotation=False,
    plot_center_of_mass = False,
).reconstruct(**reconstruct_params)
```