### PR TITLE
bug fix to __init__ func

### DIFF
--- a/py4DSTEM/process/wholepatternfit/wp_models.py
+++ b/py4DSTEM/process/wholepatternfit/wp_models.py
@@ -1117,7 +1117,7 @@ class ComplexOverlapKernelDiskLattice(WPFModel):
         name="Complex Overlapped Disk Lattice",
         verbose=False,
     ):
-        return NotImplementedError(
+        raise NotImplementedError(
             "This model type has not been updated for use with the new architecture."
         )
 


### PR DESCRIPTION
`__init__` funcs have to return None so you get a `TypeError` rather than `NotImplementedError`, changing to raise.

```python
class GoodS():
    def __init__(self):
        self.x:int = 10
        raise NotImplementedError("Not Implemented")
class BadS():
    def __init__(self):
        self.x:int = 10
        return NotImplementedError

# good class
good_s = GoodS()
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
Cell In[15], line 1
----> 1 good_s = GoodS()

Cell In[14], line 4, in GoodS.__init__(self)
      2 def __init__(self):
      3     self.x:int = 10
----> 4     raise NotImplementedError("Not Implemented")

NotImplementedError: Not Implemented
# bad class
bad_s = BadS()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[16], line 1
----> 1 bad_s = BadS()

TypeError: __init__() should return None, not 'type'
```