### PR TITLE
Fixing Google Colab Issues

### DIFF
--- a/py4DSTEM/braggvectors/diskdetection_aiml_cuda.py
+++ b/py4DSTEM/braggvectors/diskdetection_aiml_cuda.py
@@ -18,7 +18,7 @@ from py4DSTEM.braggvectors.diskdetection_aiml import _get_latest_model
 try:
     import cupy as cp
     from cupyx.scipy.ndimage import gaussian_filter
-except (ModuleNotFoundError,ImportError) as e:
+except (ModuleNotFoundError, ImportError) as e:
     raise ImportError("AIML CUDA Requires cupy") from e
 
 try:
@@ -29,7 +29,6 @@ except:
         + "https://www.tensorflow.org/install"
         + "for more information"
     )
-
 
 
 def find_Bragg_disks_aiml_CUDA(

--- a/py4DSTEM/braggvectors/diskdetection_aiml_cuda.py
+++ b/py4DSTEM/braggvectors/diskdetection_aiml_cuda.py
@@ -17,8 +17,9 @@ from py4DSTEM.braggvectors.diskdetection_aiml import _get_latest_model
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
-    raise ImportError("AIML CUDA Requires cupy")
+    from cupyx.scipy.ndimage import gaussian_filter
+except (ModuleNotFoundError,ImportError) as e:
+    raise ImportError("AIML CUDA Requires cupy") from e
 
 try:
     import tensorflow as tf
@@ -29,7 +30,6 @@ except:
         + "for more information"
     )
 
-from cupyx.scipy.ndimage import gaussian_filter
 
 
 def find_Bragg_disks_aiml_CUDA(

--- a/py4DSTEM/braggvectors/diskdetection_cuda.py
+++ b/py4DSTEM/braggvectors/diskdetection_cuda.py
@@ -4,8 +4,9 @@ Functions for finding Braggdisks using cupy
 """
 
 import numpy as np
-import cupy as cp
+
 # TODO Wanted to double check these are good unprotected
+import cupy as cp
 from cupyx.scipy.ndimage import gaussian_filter
 import cupyx.scipy.fft as cufft
 from time import time

--- a/py4DSTEM/braggvectors/diskdetection_cuda.py
+++ b/py4DSTEM/braggvectors/diskdetection_cuda.py
@@ -5,7 +5,6 @@ Functions for finding Braggdisks using cupy
 
 import numpy as np
 
-# TODO Wanted to double check these are good unprotected
 import cupy as cp
 from cupyx.scipy.ndimage import gaussian_filter
 import cupyx.scipy.fft as cufft

--- a/py4DSTEM/braggvectors/diskdetection_cuda.py
+++ b/py4DSTEM/braggvectors/diskdetection_cuda.py
@@ -5,6 +5,7 @@ Functions for finding Braggdisks using cupy
 
 import numpy as np
 import cupy as cp
+# TODO Wanted to double check these are good unprotected
 from cupyx.scipy.ndimage import gaussian_filter
 import cupyx.scipy.fft as cufft
 from time import time

--- a/py4DSTEM/braggvectors/kernels.py
+++ b/py4DSTEM/braggvectors/kernels.py
@@ -1,4 +1,3 @@
-# TODO check these are okay to leave unprotected
 import cupy as cp
 
 __all__ = ["kernels"]

--- a/py4DSTEM/braggvectors/kernels.py
+++ b/py4DSTEM/braggvectors/kernels.py
@@ -1,3 +1,4 @@
+# TODO check these are okay to leave unprotected
 import cupy as cp
 
 __all__ = ["kernels"]

--- a/py4DSTEM/preprocess/utils.py
+++ b/py4DSTEM/preprocess/utils.py
@@ -5,7 +5,7 @@ from scipy.ndimage import gaussian_filter
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     cp = np
 
 

--- a/py4DSTEM/process/diffraction/crystal_ACOM.py
+++ b/py4DSTEM/process/diffraction/crystal_ACOM.py
@@ -14,7 +14,7 @@ from numpy.linalg import lstsq
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ModuleNotFoundError,ImportError):
     cp = None
 
 

--- a/py4DSTEM/process/diffraction/crystal_ACOM.py
+++ b/py4DSTEM/process/diffraction/crystal_ACOM.py
@@ -14,7 +14,7 @@ from numpy.linalg import lstsq
 
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = None
 
 

--- a/py4DSTEM/process/phase/iterative_base_class.py
+++ b/py4DSTEM/process/phase/iterative_base_class.py
@@ -13,7 +13,7 @@ from scipy.ndimage import rotate
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ModuleNotFoundError,ImportError):
     cp = np
 
 from emdfile import Array, Custom, Metadata, _read_metadata, tqdmnd

--- a/py4DSTEM/process/phase/iterative_base_class.py
+++ b/py4DSTEM/process/phase/iterative_base_class.py
@@ -13,7 +13,7 @@ from scipy.ndimage import rotate
 
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = np
 
 from emdfile import Array, Custom, Metadata, _read_metadata, tqdmnd

--- a/py4DSTEM/process/phase/iterative_dpc.py
+++ b/py4DSTEM/process/phase/iterative_dpc.py
@@ -13,7 +13,7 @@ from mpl_toolkits.axes_grid1 import ImageGrid, make_axes_locatable
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ModuleNotFoundError,ImportError):
     cp = np
 
 from emdfile import Array, Custom, Metadata, _read_metadata, tqdmnd

--- a/py4DSTEM/process/phase/iterative_dpc.py
+++ b/py4DSTEM/process/phase/iterative_dpc.py
@@ -13,7 +13,7 @@ from mpl_toolkits.axes_grid1 import ImageGrid, make_axes_locatable
 
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = np
 
 from emdfile import Array, Custom, Metadata, _read_metadata, tqdmnd

--- a/py4DSTEM/process/phase/iterative_mixedstate_multislice_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_mixedstate_multislice_ptychography.py
@@ -8,7 +8,6 @@ from typing import Mapping, Sequence, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pylops
 from matplotlib.gridspec import GridSpec
 from mpl_toolkits.axes_grid1 import ImageGrid, make_axes_locatable
 from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg, show_complex
@@ -17,7 +16,10 @@ try:
     import cupy as cp
 except (ModuleNotFoundError,ImportError):
     cp = None
-
+    import os
+    # make sure pylops doesn't try to use cupy
+    os.environ["CUPY_PYLOPS"] = "0"
+import pylops # this must follow the exception 
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube
 from py4DSTEM.process.phase.iterative_base_class import PtychographicReconstruction

--- a/py4DSTEM/process/phase/iterative_mixedstate_multislice_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_mixedstate_multislice_ptychography.py
@@ -14,12 +14,13 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg, show_c
 
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = None
     import os
+
     # make sure pylops doesn't try to use cupy
     os.environ["CUPY_PYLOPS"] = "0"
-import pylops # this must follow the exception 
+import pylops  # this must follow the exception
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube
 from py4DSTEM.process.phase.iterative_base_class import PtychographicReconstruction

--- a/py4DSTEM/process/phase/iterative_mixedstate_multislice_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_mixedstate_multislice_ptychography.py
@@ -15,7 +15,7 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg, show_c
 
 try:
     import cupy as cp
-except ImportError:
+except (ModuleNotFoundError,ImportError):
     cp = None
 
 from emdfile import Custom, tqdmnd

--- a/py4DSTEM/process/phase/iterative_mixedstate_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_mixedstate_ptychography.py
@@ -14,7 +14,7 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg, show_c
 
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = np
 
 from emdfile import Custom, tqdmnd

--- a/py4DSTEM/process/phase/iterative_mixedstate_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_mixedstate_ptychography.py
@@ -14,7 +14,7 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg, show_c
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ModuleNotFoundError,ImportError):
     cp = np
 
 from emdfile import Custom, tqdmnd

--- a/py4DSTEM/process/phase/iterative_multislice_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_multislice_ptychography.py
@@ -8,7 +8,6 @@ from typing import Mapping, Sequence, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pylops
 from matplotlib.gridspec import GridSpec
 from mpl_toolkits.axes_grid1 import ImageGrid, make_axes_locatable
 from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg, show_complex
@@ -17,7 +16,10 @@ try:
     import cupy as cp
 except (ModuleNotFoundError,ImportError):
     cp = np
-
+    import os
+    # make sure pylops doesn't try to use cupy
+    os.environ["CUPY_PYLOPS"] = "0"
+import pylops # this must follow the exception
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube
 from py4DSTEM.process.phase.iterative_base_class import PtychographicReconstruction

--- a/py4DSTEM/process/phase/iterative_multislice_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_multislice_ptychography.py
@@ -14,12 +14,13 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg, show_c
 
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = np
     import os
+
     # make sure pylops doesn't try to use cupy
     os.environ["CUPY_PYLOPS"] = "0"
-import pylops # this must follow the exception
+import pylops  # this must follow the exception
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube
 from py4DSTEM.process.phase.iterative_base_class import PtychographicReconstruction

--- a/py4DSTEM/process/phase/iterative_multislice_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_multislice_ptychography.py
@@ -15,7 +15,7 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg, show_c
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ModuleNotFoundError,ImportError):
     cp = np
 
 from emdfile import Custom, tqdmnd

--- a/py4DSTEM/process/phase/iterative_overlap_magnetic_tomography.py
+++ b/py4DSTEM/process/phase/iterative_overlap_magnetic_tomography.py
@@ -17,7 +17,7 @@ from scipy.ndimage import rotate as rotate_np
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ModuleNotFoundError,ImportError):
     cp = np
 
 from emdfile import Custom, tqdmnd

--- a/py4DSTEM/process/phase/iterative_overlap_magnetic_tomography.py
+++ b/py4DSTEM/process/phase/iterative_overlap_magnetic_tomography.py
@@ -16,12 +16,13 @@ from scipy.ndimage import rotate as rotate_np
 
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = np
     import os
+
     # make sure pylops doesn't try to use cupy
     os.environ["CUPY_PYLOPS"] = "0"
-import pylops # this must follow the exception
+import pylops  # this must follow the exception
 
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube

--- a/py4DSTEM/process/phase/iterative_overlap_magnetic_tomography.py
+++ b/py4DSTEM/process/phase/iterative_overlap_magnetic_tomography.py
@@ -8,7 +8,6 @@ from typing import Mapping, Sequence, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pylops
 from matplotlib.gridspec import GridSpec
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from py4DSTEM.visualize import show
@@ -19,6 +18,10 @@ try:
     import cupy as cp
 except (ModuleNotFoundError,ImportError):
     cp = np
+    import os
+    # make sure pylops doesn't try to use cupy
+    os.environ["CUPY_PYLOPS"] = "0"
+import pylops # this must follow the exception
 
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube

--- a/py4DSTEM/process/phase/iterative_overlap_tomography.py
+++ b/py4DSTEM/process/phase/iterative_overlap_tomography.py
@@ -8,7 +8,6 @@ from typing import Mapping, Sequence, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pylops
 from matplotlib.gridspec import GridSpec
 from mpl_toolkits.axes_grid1 import ImageGrid, make_axes_locatable
 from py4DSTEM.visualize import show
@@ -19,6 +18,10 @@ try:
     import cupy as cp
 except (ModuleNotFoundError,ImportError):
     cp = np
+    import os
+    # make sure pylops doesn't try to use cupy
+    os.environ["CUPY_PYLOPS"] = "0"
+import pylops # this must follow the exception
 
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube

--- a/py4DSTEM/process/phase/iterative_overlap_tomography.py
+++ b/py4DSTEM/process/phase/iterative_overlap_tomography.py
@@ -17,7 +17,7 @@ from scipy.ndimage import rotate as rotate_np
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ModuleNotFoundError,ImportError):
     cp = np
 
 from emdfile import Custom, tqdmnd

--- a/py4DSTEM/process/phase/iterative_overlap_tomography.py
+++ b/py4DSTEM/process/phase/iterative_overlap_tomography.py
@@ -16,12 +16,13 @@ from scipy.ndimage import rotate as rotate_np
 
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = np
     import os
+
     # make sure pylops doesn't try to use cupy
     os.environ["CUPY_PYLOPS"] = "0"
-import pylops # this must follow the exception
+import pylops  # this must follow the exception
 
 from emdfile import Custom, tqdmnd
 from py4DSTEM import DataCube

--- a/py4DSTEM/process/phase/iterative_parallax.py
+++ b/py4DSTEM/process/phase/iterative_parallax.py
@@ -24,7 +24,7 @@ from scipy.special import comb
 
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = np
 
 warnings.simplefilter(action="always", category=UserWarning)

--- a/py4DSTEM/process/phase/iterative_parallax.py
+++ b/py4DSTEM/process/phase/iterative_parallax.py
@@ -24,7 +24,7 @@ from scipy.special import comb
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ModuleNotFoundError,ImportError):
     cp = np
 
 warnings.simplefilter(action="always", category=UserWarning)

--- a/py4DSTEM/process/phase/iterative_ptychographic_constraints.py
+++ b/py4DSTEM/process/phase/iterative_ptychographic_constraints.py
@@ -9,14 +9,17 @@ from py4DSTEM.process.phase.utils import (
     regularize_probe_amplitude,
 )
 from py4DSTEM.process.utils import get_CoM
+
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = np
     import os
+
     # make sure pylops doesn't try to use cupy
     os.environ["CUPY_PYLOPS"] = "0"
-import pylops # this must follow the exception
+import pylops  # this must follow the exception
+
 
 class PtychographicConstraints:
     """

--- a/py4DSTEM/process/phase/iterative_ptychographic_constraints.py
+++ b/py4DSTEM/process/phase/iterative_ptychographic_constraints.py
@@ -1,7 +1,6 @@
 import warnings
 
 import numpy as np
-import pylops
 from py4DSTEM.process.phase.utils import (
     array_slice,
     estimate_global_transformation_ransac,
@@ -10,7 +9,14 @@ from py4DSTEM.process.phase.utils import (
     regularize_probe_amplitude,
 )
 from py4DSTEM.process.utils import get_CoM
-
+try:
+    import cupy as cp
+except (ModuleNotFoundError,ImportError):
+    cp = np
+    import os
+    # make sure pylops doesn't try to use cupy
+    os.environ["CUPY_PYLOPS"] = "0"
+import pylops # this must follow the exception
 
 class PtychographicConstraints:
     """

--- a/py4DSTEM/process/phase/iterative_simultaneous_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_simultaneous_ptychography.py
@@ -14,7 +14,7 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg
 
 try:
     import cupy as cp
-except (ImportError,ModuleNotFoundError):
+except (ImportError, ModuleNotFoundError):
     cp = np
 
 from emdfile import Custom, tqdmnd

--- a/py4DSTEM/process/phase/iterative_simultaneous_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_simultaneous_ptychography.py
@@ -14,7 +14,7 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ImportError,ModuleNotFoundError):
     cp = np
 
 from emdfile import Custom, tqdmnd

--- a/py4DSTEM/process/phase/iterative_singleslice_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_singleslice_ptychography.py
@@ -14,7 +14,7 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg
 
 try:
     import cupy as cp
-except (ImportError,ModuleNotFoundError):
+except (ImportError, ModuleNotFoundError):
     cp = np
 
 from emdfile import Custom, tqdmnd

--- a/py4DSTEM/process/phase/iterative_singleslice_ptychography.py
+++ b/py4DSTEM/process/phase/iterative_singleslice_ptychography.py
@@ -14,7 +14,7 @@ from py4DSTEM.visualize.vis_special import Complex2RGB, add_colorbar_arg
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ImportError,ModuleNotFoundError):
     cp = np
 
 from emdfile import Custom, tqdmnd

--- a/py4DSTEM/process/phase/utils.py
+++ b/py4DSTEM/process/phase/utils.py
@@ -8,7 +8,7 @@ from scipy.optimize import curve_fit
 try:
     import cupy as cp
     from cupyx.scipy.fft import rfft
-except ImportError:
+except (ImportError,ModuleNotFoundError):
     cp = None
     from scipy.fft import dstn, idstn
 

--- a/py4DSTEM/process/phase/utils.py
+++ b/py4DSTEM/process/phase/utils.py
@@ -8,7 +8,7 @@ from scipy.optimize import curve_fit
 try:
     import cupy as cp
     from cupyx.scipy.fft import rfft
-except (ImportError,ModuleNotFoundError):
+except (ImportError, ModuleNotFoundError):
     cp = None
     from scipy.fft import dstn, idstn
 

--- a/py4DSTEM/process/utils/cross_correlate.py
+++ b/py4DSTEM/process/utils/cross_correlate.py
@@ -6,7 +6,7 @@ from py4DSTEM.process.utils.multicorr import upsampled_correlation
 
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = np
 
 

--- a/py4DSTEM/process/utils/cross_correlate.py
+++ b/py4DSTEM/process/utils/cross_correlate.py
@@ -6,7 +6,7 @@ from py4DSTEM.process.utils.multicorr import upsampled_correlation
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ModuleNotFoundError,ImportError):
     cp = np
 
 

--- a/py4DSTEM/process/utils/multicorr.py
+++ b/py4DSTEM/process/utils/multicorr.py
@@ -15,7 +15,7 @@ import numpy as np
 
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = np
 
 

--- a/py4DSTEM/process/utils/multicorr.py
+++ b/py4DSTEM/process/utils/multicorr.py
@@ -15,7 +15,7 @@ import numpy as np
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ModuleNotFoundError,ImportError):
     cp = np
 
 

--- a/py4DSTEM/process/utils/utils.py
+++ b/py4DSTEM/process/utils/utils.py
@@ -24,7 +24,7 @@ except ImportError:
 
 try:
     import cupy as cp
-except (ModuleNotFoundError,ImportError):
+except (ModuleNotFoundError, ImportError):
     cp = np
 
 

--- a/py4DSTEM/process/utils/utils.py
+++ b/py4DSTEM/process/utils/utils.py
@@ -24,7 +24,7 @@ except ImportError:
 
 try:
     import cupy as cp
-except ModuleNotFoundError:
+except (ModuleNotFoundError,ImportError):
     cp = np
 
 


### PR DESCRIPTION
This PR changes the except behaviour for `Cupy` and `pylops` so that in envrionments which have cupy installed incorrectly py4DSTEM can still import correctly. Its a patch fix, and it might be worth thinking how the Exceptions are handled and if they should raise warnings about the state of cupy imported, as it may currently just convert cupy to numpy somewhat silently. 

`pylops` was throwing an error as it determines the cupy envrionment by:

```python
cupy_enabled = (
    util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYLOPS", 1)) == 1
)
```
which when `cupy` is installed incorrectly can still return True.

I found this using:

```python
import traceback

try:
  import py4DSTEM
except Exception:
    print(traceback.format_exc())
```