### PR TITLE
adding dependabot functionality 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "23:00"


### PR DESCRIPTION
This adds dependabot functionality to check and create PRs for updates in our GitHub actions dependencies. Similar to the vulnerability one was raised in #593 . 

We could extend this to check pip packages, but I've left this out as it is a more breaking change. 

```
  - package-ecosystem: "pip" # See documentation for possible values
    directory: "/" # Location of package manifests
    schedule:
      interval: "weekly"
      day: "sunday"
      time: "23:00"
    ignore:
      - dependency-name: "tensorflow"
      - dependency-name: "tensorflow-addons"
      
 ```