### PR TITLE
Release memory after Bayesian optimization

### DIFF
--- a/py4DSTEM/braggvectors/diskdetection_cuda.py
+++ b/py4DSTEM/braggvectors/diskdetection_cuda.py
@@ -156,9 +156,11 @@ def find_Bragg_disks_CUDA(
                 patt_idx = batch_idx * batch_size + subbatch_idx
                 rx, ry = np.unravel_index(patt_idx, (datacube.R_Nx, datacube.R_Ny))
                 batched_subcube[subbatch_idx, :, :] = cp.array(
-                    datacube.data[rx, ry, :, :]
-                    if filter_function is None
-                    else filter_function(datacube.data[rx, ry, :, :]),
+                    (
+                        datacube.data[rx, ry, :, :]
+                        if filter_function is None
+                        else filter_function(datacube.data[rx, ry, :, :])
+                    ),
                     dtype=cp.float32,
                 )
 

--- a/py4DSTEM/io/importfile.py
+++ b/py4DSTEM/io/importfile.py
@@ -75,7 +75,7 @@ def import_file(
         "gatan_K2_bin",
         "mib",
         "arina",
-        "abTEM"
+        "abTEM",
         # "kitware_counted",
     ], "Error: filetype not recognized"
 

--- a/py4DSTEM/io/legacy/legacy13/v13_emd_classes/io.py
+++ b/py4DSTEM/io/legacy/legacy13/v13_emd_classes/io.py
@@ -361,7 +361,7 @@ def Array_to_h5(array, group):
     data = grp.create_dataset(
         "data",
         shape=array.data.shape,
-        data=array.data
+        data=array.data,
         # dtype = type(array.data)
     )
     data.attrs.create(

--- a/py4DSTEM/process/diffraction/WK_scattering_factors.py
+++ b/py4DSTEM/process/diffraction/WK_scattering_factors.py
@@ -221,9 +221,7 @@ def RI1(BI, BJ, G):
     ri1[sub] = np.pi * (BI * np.log((BI + BJ) / BI) + BJ * np.log((BI + BJ) / BJ))
 
     sub = np.logical_and(eps <= 0.1, G > 0.0)
-    temp = 0.5 * BI**2 * np.log(BI / (BI + BJ)) + 0.5 * BJ**2 * np.log(
-        BJ / (BI + BJ)
-    )
+    temp = 0.5 * BI**2 * np.log(BI / (BI + BJ)) + 0.5 * BJ**2 * np.log(BJ / (BI + BJ))
     temp += 0.75 * (BI**2 + BJ**2) - 0.25 * (BI + BJ) ** 2
     temp -= 0.5 * (BI - BJ) ** 2
     ri1[sub] += np.pi * G[sub] ** 2 * temp

--- a/py4DSTEM/process/diffraction/crystal_viz.py
+++ b/py4DSTEM/process/diffraction/crystal_viz.py
@@ -454,8 +454,7 @@ def plot_scattering_intensity(
     int_sf_plot = calc_1D_profile(
         k,
         self.g_vec_leng,
-        (self.struct_factors_int**int_power_scale)
-        * (self.g_vec_leng**k_power_scale),
+        (self.struct_factors_int**int_power_scale) * (self.g_vec_leng**k_power_scale),
         remove_origin=True,
         k_broadening=k_broadening,
         int_scale=int_scale,

--- a/py4DSTEM/process/fit/fit.py
+++ b/py4DSTEM/process/fit/fit.py
@@ -169,8 +169,7 @@ def polar_gaussian_2D(
     # t2 = np.min(np.vstack([t,1-t]))
     t2 = np.square(t - mu_t)
     return (
-        I0 * np.exp(-(t2 / (2 * sigma_t**2) + (q - mu_q) ** 2 / (2 * sigma_q**2)))
-        + C
+        I0 * np.exp(-(t2 / (2 * sigma_t**2) + (q - mu_q) ** 2 / (2 * sigma_q**2))) + C
     )
 
 

--- a/py4DSTEM/process/phase/magnetic_ptychographic_tomography.py
+++ b/py4DSTEM/process/phase/magnetic_ptychographic_tomography.py
@@ -1201,20 +1201,20 @@ class MagneticPtychographicTomography(
 
                     # position correction
                     if not fix_positions and a0 > 0:
-                        self._positions_px_all[
-                            batch_indices
-                        ] = self._position_correction(
-                            object_sliced,
-                            vectorized_patch_indices_row,
-                            vectorized_patch_indices_col,
-                            shifted_probes,
-                            overlap,
-                            amplitudes_device,
-                            positions_px,
-                            positions_px_initial,
-                            positions_step_size,
-                            max_position_update_distance,
-                            max_position_total_distance,
+                        self._positions_px_all[batch_indices] = (
+                            self._position_correction(
+                                object_sliced,
+                                vectorized_patch_indices_row,
+                                vectorized_patch_indices_col,
+                                shifted_probes,
+                                overlap,
+                                amplitudes_device,
+                                positions_px,
+                                positions_px_initial,
+                                positions_step_size,
+                                max_position_update_distance,
+                                max_position_total_distance,
+                            )
                         )
 
                     measurement_error += batch_error
@@ -1320,10 +1320,12 @@ class MagneticPtychographicTomography(
                         butterworth_order=butterworth_order,
                         object_positivity=object_positivity,
                         shrinkage_rad=shrinkage_rad,
-                        object_mask=self._object_fov_mask_inverse
-                        if fix_potential_baseline
-                        and self._object_fov_mask_inverse.sum() > 0
-                        else None,
+                        object_mask=(
+                            self._object_fov_mask_inverse
+                            if fix_potential_baseline
+                            and self._object_fov_mask_inverse.sum() > 0
+                            else None
+                        ),
                         tv_denoise=tv_denoise and tv_denoise_weights is not None,
                         tv_denoise_weights=tv_denoise_weights,
                         tv_denoise_inner_iter=tv_denoise_inner_iter,
@@ -1353,10 +1355,12 @@ class MagneticPtychographicTomography(
                     butterworth_order=butterworth_order,
                     object_positivity=object_positivity,
                     shrinkage_rad=shrinkage_rad,
-                    object_mask=self._object_fov_mask_inverse
-                    if fix_potential_baseline
-                    and self._object_fov_mask_inverse.sum() > 0
-                    else None,
+                    object_mask=(
+                        self._object_fov_mask_inverse
+                        if fix_potential_baseline
+                        and self._object_fov_mask_inverse.sum() > 0
+                        else None
+                    ),
                     tv_denoise=tv_denoise and tv_denoise_weights is not None,
                     tv_denoise_weights=tv_denoise_weights,
                     tv_denoise_inner_iter=tv_denoise_inner_iter,

--- a/py4DSTEM/process/phase/magnetic_ptychography.py
+++ b/py4DSTEM/process/phase/magnetic_ptychography.py
@@ -1447,20 +1447,20 @@ class MagneticPtychography(
 
                     # position correction
                     if not fix_positions and a0 > 0:
-                        self._positions_px_all[
-                            batch_indices
-                        ] = self._position_correction(
-                            self._object,
-                            vectorized_patch_indices_row,
-                            vectorized_patch_indices_col,
-                            shifted_probes,
-                            overlap,
-                            amplitudes_device,
-                            positions_px,
-                            positions_px_initial,
-                            positions_step_size,
-                            max_position_update_distance,
-                            max_position_total_distance,
+                        self._positions_px_all[batch_indices] = (
+                            self._position_correction(
+                                self._object,
+                                vectorized_patch_indices_row,
+                                vectorized_patch_indices_col,
+                                shifted_probes,
+                                overlap,
+                                amplitudes_device,
+                                positions_px,
+                                positions_px_initial,
+                                positions_step_size,
+                                max_position_update_distance,
+                                max_position_total_distance,
+                            )
                         )
 
                     measurement_error += batch_error
@@ -1555,10 +1555,12 @@ class MagneticPtychography(
                         tv_denoise_inner_iter=tv_denoise_inner_iter,
                         object_positivity=object_positivity,
                         shrinkage_rad=shrinkage_rad,
-                        object_mask=self._object_fov_mask_inverse
-                        if fix_potential_baseline
-                        and self._object_fov_mask_inverse.sum() > 0
-                        else None,
+                        object_mask=(
+                            self._object_fov_mask_inverse
+                            if fix_potential_baseline
+                            and self._object_fov_mask_inverse.sum() > 0
+                            else None
+                        ),
                         pure_phase_object=pure_phase_object
                         and self._object_type == "complex",
                     )
@@ -1588,10 +1590,12 @@ class MagneticPtychography(
                     tv_denoise_inner_iter=tv_denoise_inner_iter,
                     object_positivity=object_positivity,
                     shrinkage_rad=shrinkage_rad,
-                    object_mask=self._object_fov_mask_inverse
-                    if fix_potential_baseline
-                    and self._object_fov_mask_inverse.sum() > 0
-                    else None,
+                    object_mask=(
+                        self._object_fov_mask_inverse
+                        if fix_potential_baseline
+                        and self._object_fov_mask_inverse.sum() > 0
+                        else None
+                    ),
                     pure_phase_object=pure_phase_object
                     and self._object_type == "complex",
                 )

--- a/py4DSTEM/process/phase/mixedstate_multislice_ptychography.py
+++ b/py4DSTEM/process/phase/mixedstate_multislice_ptychography.py
@@ -1047,16 +1047,21 @@ class MixedstateMultislicePtychography(
                 butterworth_order=butterworth_order,
                 kz_regularization_filter=kz_regularization_filter
                 and kz_regularization_gamma is not None,
-                kz_regularization_gamma=kz_regularization_gamma[a0]
-                if kz_regularization_gamma is not None
-                and isinstance(kz_regularization_gamma, np.ndarray)
-                else kz_regularization_gamma,
+                kz_regularization_gamma=(
+                    kz_regularization_gamma[a0]
+                    if kz_regularization_gamma is not None
+                    and isinstance(kz_regularization_gamma, np.ndarray)
+                    else kz_regularization_gamma
+                ),
                 identical_slices=identical_slices,
                 object_positivity=object_positivity,
                 shrinkage_rad=shrinkage_rad,
-                object_mask=self._object_fov_mask_inverse
-                if fix_potential_baseline and self._object_fov_mask_inverse.sum() > 0
-                else None,
+                object_mask=(
+                    self._object_fov_mask_inverse
+                    if fix_potential_baseline
+                    and self._object_fov_mask_inverse.sum() > 0
+                    else None
+                ),
                 pure_phase_object=pure_phase_object and self._object_type == "complex",
                 tv_denoise_chambolle=tv_denoise_chambolle
                 and tv_denoise_weight_chambolle is not None,

--- a/py4DSTEM/process/phase/mixedstate_ptychography.py
+++ b/py4DSTEM/process/phase/mixedstate_ptychography.py
@@ -941,9 +941,12 @@ class MixedstatePtychography(
                 tv_denoise_inner_iter=tv_denoise_inner_iter,
                 object_positivity=object_positivity,
                 shrinkage_rad=shrinkage_rad,
-                object_mask=self._object_fov_mask_inverse
-                if fix_potential_baseline and self._object_fov_mask_inverse.sum() > 0
-                else None,
+                object_mask=(
+                    self._object_fov_mask_inverse
+                    if fix_potential_baseline
+                    and self._object_fov_mask_inverse.sum() > 0
+                    else None
+                ),
                 pure_phase_object=pure_phase_object and self._object_type == "complex",
             )
 

--- a/py4DSTEM/process/phase/multislice_ptychography.py
+++ b/py4DSTEM/process/phase/multislice_ptychography.py
@@ -1030,9 +1030,12 @@ class MultislicePtychography(
                 identical_slices=identical_slices,
                 object_positivity=object_positivity,
                 shrinkage_rad=shrinkage_rad,
-                object_mask=self._object_fov_mask_inverse
-                if fix_potential_baseline and self._object_fov_mask_inverse.sum() > 0
-                else None,
+                object_mask=(
+                    self._object_fov_mask_inverse
+                    if fix_potential_baseline
+                    and self._object_fov_mask_inverse.sum() > 0
+                    else None
+                ),
                 pure_phase_object=pure_phase_object and self._object_type == "complex",
                 tv_denoise_chambolle=tv_denoise_chambolle
                 and tv_denoise_weight_chambolle is not None,

--- a/py4DSTEM/process/phase/parallax.py
+++ b/py4DSTEM/process/phase/parallax.py
@@ -2194,16 +2194,16 @@ class Parallax(PhaseReconstruction):
                 measured_shifts_sx = xp.zeros(
                     self._region_of_interest_shape, dtype=xp.float32
                 )
-                measured_shifts_sx[
-                    self._xy_inds[:, 0], self._xy_inds[:, 1]
-                ] = self._xy_shifts_Ang[:, 0]
+                measured_shifts_sx[self._xy_inds[:, 0], self._xy_inds[:, 1]] = (
+                    self._xy_shifts_Ang[:, 0]
+                )
 
                 measured_shifts_sy = xp.zeros(
                     self._region_of_interest_shape, dtype=xp.float32
                 )
-                measured_shifts_sy[
-                    self._xy_inds[:, 0], self._xy_inds[:, 1]
-                ] = self._xy_shifts_Ang[:, 1]
+                measured_shifts_sy[self._xy_inds[:, 0], self._xy_inds[:, 1]] = (
+                    self._xy_shifts_Ang[:, 1]
+                )
 
                 fitted_shifts = (
                     xp.tensordot(gradients, xp.array(self._aberrations_coefs), axes=1)
@@ -2214,16 +2214,16 @@ class Parallax(PhaseReconstruction):
                 fitted_shifts_sx = xp.zeros(
                     self._region_of_interest_shape, dtype=xp.float32
                 )
-                fitted_shifts_sx[
-                    self._xy_inds[:, 0], self._xy_inds[:, 1]
-                ] = fitted_shifts[:, 0]
+                fitted_shifts_sx[self._xy_inds[:, 0], self._xy_inds[:, 1]] = (
+                    fitted_shifts[:, 0]
+                )
 
                 fitted_shifts_sy = xp.zeros(
                     self._region_of_interest_shape, dtype=xp.float32
                 )
-                fitted_shifts_sy[
-                    self._xy_inds[:, 0], self._xy_inds[:, 1]
-                ] = fitted_shifts[:, 1]
+                fitted_shifts_sy[self._xy_inds[:, 0], self._xy_inds[:, 1]] = (
+                    fitted_shifts[:, 1]
+                )
 
                 max_shift = xp.max(
                     xp.array(
@@ -2520,8 +2520,7 @@ class Parallax(PhaseReconstruction):
                 SNR_inv = (
                     xp.sqrt(
                         1
-                        + (kra2**k_info_power)
-                        / ((k_info_limit) ** (2 * k_info_power))
+                        + (kra2**k_info_power) / ((k_info_limit) ** (2 * k_info_power))
                     )
                     / Wiener_signal_noise_ratio
                 )

--- a/py4DSTEM/process/phase/parameter_optimize.py
+++ b/py4DSTEM/process/phase/parameter_optimize.py
@@ -327,7 +327,7 @@ class PtychographyOptimizer:
             for p, x in zip(self._parameter_list, self._skopt_result.x):
                 print(f"{p.name}: {x}")
         finally:
-            # close the pbar and clear memory gracefully on interrupt
+            # close the pbar gracefully on interrupt
             pbar.close()
 
         return self

--- a/py4DSTEM/process/phase/parameter_optimize.py
+++ b/py4DSTEM/process/phase/parameter_optimize.py
@@ -645,6 +645,7 @@ class PtychographyOptimizer:
     def _set_optimizer_defaults(
         self,
         verbose=False,
+        clear_fft_cache=False,
         plot_center_of_mass=False,
         plot_rotation=False,
         plot_probe_overlaps=False,
@@ -656,7 +657,7 @@ class PtychographyOptimizer:
         Set all of the verbose and plotting to False, allowing for user-overwrite.
         """
         self._init_static_args["verbose"] = verbose
-        self._init_static_args["clear_fft_cache"] = False
+        self._init_static_args["clear_fft_cache"] = clear_fft_cache
 
         self._preprocess_static_args["plot_center_of_mass"] = plot_center_of_mass
         self._preprocess_static_args["plot_rotation"] = plot_rotation

--- a/py4DSTEM/process/phase/parameter_optimize.py
+++ b/py4DSTEM/process/phase/parameter_optimize.py
@@ -323,16 +323,18 @@ class PtychographyOptimizer:
                 **skopt_kwargs,
             )
 
-            # Remove the optimization result's reference to the function, as it potentially contains a 
+            # Remove the optimization result's reference to the function, as it potentially contains a
             # copy of the ptycho object
-            del self._skopt_result['fun']
+            del self._skopt_result["fun"]
 
             # If using the GPU, free some cached stuff
             if self._init_args.get("device", "cpu") == "gpu":
                 import cupy as cp
+
                 cp.get_default_memory_pool().free_all_blocks()
                 cp.get_default_pinned_memory_pool().free_all_blocks()
                 from cupy.fft.config import get_plan_cache
+
                 get_plan_cache().clear()
 
             print("Optimized parameters:")

--- a/py4DSTEM/process/phase/parameter_optimize.py
+++ b/py4DSTEM/process/phase/parameter_optimize.py
@@ -656,6 +656,7 @@ class PtychographyOptimizer:
         Set all of the verbose and plotting to False, allowing for user-overwrite.
         """
         self._init_static_args["verbose"] = verbose
+        self._init_static_args["clear_fft_cache"] = False
 
         self._preprocess_static_args["plot_center_of_mass"] = plot_center_of_mass
         self._preprocess_static_args["plot_rotation"] = plot_rotation

--- a/py4DSTEM/process/phase/parameter_optimize.py
+++ b/py4DSTEM/process/phase/parameter_optimize.py
@@ -323,6 +323,18 @@ class PtychographyOptimizer:
                 **skopt_kwargs,
             )
 
+            # Remove the optimization result's reference to the function, as it potentially contains a 
+            # copy of the ptycho object
+            del self._skopt_result['fun']
+
+            # If using the GPU, free some cached stuff
+            if self._init_args.get("device", "cpu") == "gpu":
+                import cupy as cp
+                cp.get_default_memory_pool().free_all_blocks()
+                cp.get_default_pinned_memory_pool().free_all_blocks()
+                from cupy.fft.config import get_plan_cache
+                get_plan_cache().clear()
+
             print("Optimized parameters:")
             for p, x in zip(self._parameter_list, self._skopt_result.x):
                 print(f"{p.name}: {x}")

--- a/py4DSTEM/process/phase/phase_base_class.py
+++ b/py4DSTEM/process/phase/phase_base_class.py
@@ -997,17 +997,21 @@ class PhaseReconstruction(Custom):
                     if _rotation_best_transpose:
                         ax.plot(
                             rotation_angles_deg,
-                            asnumpy(rotation_div_transpose)
-                            if maximize_divergence
-                            else asnumpy(rotation_curl_transpose),
+                            (
+                                asnumpy(rotation_div_transpose)
+                                if maximize_divergence
+                                else asnumpy(rotation_curl_transpose)
+                            ),
                             label="CoM after transpose",
                         )
                     else:
                         ax.plot(
                             rotation_angles_deg,
-                            asnumpy(rotation_div)
-                            if maximize_divergence
-                            else asnumpy(rotation_curl),
+                            (
+                                asnumpy(rotation_div)
+                                if maximize_divergence
+                                else asnumpy(rotation_curl)
+                            ),
                             label="CoM",
                         )
 
@@ -1159,16 +1163,20 @@ class PhaseReconstruction(Custom):
 
                     ax.plot(
                         rotation_angles_deg,
-                        asnumpy(rotation_div)
-                        if maximize_divergence
-                        else asnumpy(rotation_curl),
+                        (
+                            asnumpy(rotation_div)
+                            if maximize_divergence
+                            else asnumpy(rotation_curl)
+                        ),
                         label="CoM",
                     )
                     ax.plot(
                         rotation_angles_deg,
-                        asnumpy(rotation_div_transpose)
-                        if maximize_divergence
-                        else asnumpy(rotation_curl_transpose),
+                        (
+                            asnumpy(rotation_div_transpose)
+                            if maximize_divergence
+                            else asnumpy(rotation_curl_transpose)
+                        ),
                         label="CoM after transpose",
                     )
                     y_r = ax.get_ylim()

--- a/py4DSTEM/process/phase/ptychographic_methods.py
+++ b/py4DSTEM/process/phase/ptychographic_methods.py
@@ -345,9 +345,7 @@ class Object2p5DMethodsMixin:
             propagators[i] = xp.exp(
                 1.0j * (-(kx**2)[:, None] * np.pi * wavelength * dz)
             )
-            propagators[i] *= xp.exp(
-                1.0j * (-(ky**2)[None] * np.pi * wavelength * dz)
-            )
+            propagators[i] *= xp.exp(1.0j * (-(ky**2)[None] * np.pi * wavelength * dz))
 
             if theta_x is not None:
                 propagators[i] *= xp.exp(

--- a/py4DSTEM/process/phase/ptychographic_tomography.py
+++ b/py4DSTEM/process/phase/ptychographic_tomography.py
@@ -1093,20 +1093,20 @@ class PtychographicTomography(
 
                     # position correction
                     if not fix_positions:
-                        self._positions_px_all[
-                            batch_indices
-                        ] = self._position_correction(
-                            object_sliced,
-                            vectorized_patch_indices_row,
-                            vectorized_patch_indices_col,
-                            shifted_probes,
-                            overlap,
-                            amplitudes_device,
-                            positions_px,
-                            positions_px_initial,
-                            positions_step_size,
-                            max_position_update_distance,
-                            max_position_total_distance,
+                        self._positions_px_all[batch_indices] = (
+                            self._position_correction(
+                                object_sliced,
+                                vectorized_patch_indices_row,
+                                vectorized_patch_indices_col,
+                                shifted_probes,
+                                overlap,
+                                amplitudes_device,
+                                positions_px,
+                                positions_px_initial,
+                                positions_step_size,
+                                max_position_update_distance,
+                                max_position_total_distance,
+                            )
                         )
 
                     measurement_error += batch_error
@@ -1206,10 +1206,12 @@ class PtychographicTomography(
                         butterworth_order=butterworth_order,
                         object_positivity=object_positivity,
                         shrinkage_rad=shrinkage_rad,
-                        object_mask=self._object_fov_mask_inverse
-                        if fix_potential_baseline
-                        and self._object_fov_mask_inverse.sum() > 0
-                        else None,
+                        object_mask=(
+                            self._object_fov_mask_inverse
+                            if fix_potential_baseline
+                            and self._object_fov_mask_inverse.sum() > 0
+                            else None
+                        ),
                         tv_denoise=tv_denoise and tv_denoise_weights is not None,
                         tv_denoise_weights=tv_denoise_weights,
                         tv_denoise_inner_iter=tv_denoise_inner_iter,
@@ -1236,10 +1238,12 @@ class PtychographicTomography(
                     butterworth_order=butterworth_order,
                     object_positivity=object_positivity,
                     shrinkage_rad=shrinkage_rad,
-                    object_mask=self._object_fov_mask_inverse
-                    if fix_potential_baseline
-                    and self._object_fov_mask_inverse.sum() > 0
-                    else None,
+                    object_mask=(
+                        self._object_fov_mask_inverse
+                        if fix_potential_baseline
+                        and self._object_fov_mask_inverse.sum() > 0
+                        else None
+                    ),
                     tv_denoise=tv_denoise and tv_denoise_weights is not None,
                     tv_denoise_weights=tv_denoise_weights,
                     tv_denoise_inner_iter=tv_denoise_inner_iter,

--- a/py4DSTEM/process/phase/ptychographic_visualizations.py
+++ b/py4DSTEM/process/phase/ptychographic_visualizations.py
@@ -384,9 +384,11 @@ class VisualizationsMixin:
         grid = ImageGrid(
             fig,
             spec[0],
-            nrows_ncols=(1, iterations_grid[1])
-            if (plot_probe or plot_fourier_probe)
-            else iterations_grid,
+            nrows_ncols=(
+                (1, iterations_grid[1])
+                if (plot_probe or plot_fourier_probe)
+                else iterations_grid
+            ),
             axes_pad=(0.75, 0.5) if cbar else 0.5,
             cbar_mode="each" if cbar else None,
             cbar_pad="2.5%" if cbar else None,

--- a/py4DSTEM/process/phase/singleslice_ptychography.py
+++ b/py4DSTEM/process/phase/singleslice_ptychography.py
@@ -916,9 +916,12 @@ class SingleslicePtychography(
                 tv_denoise_inner_iter=tv_denoise_inner_iter,
                 object_positivity=object_positivity,
                 shrinkage_rad=shrinkage_rad,
-                object_mask=self._object_fov_mask_inverse
-                if fix_potential_baseline and self._object_fov_mask_inverse.sum() > 0
-                else None,
+                object_mask=(
+                    self._object_fov_mask_inverse
+                    if fix_potential_baseline
+                    and self._object_fov_mask_inverse.sum() > 0
+                    else None
+                ),
                 pure_phase_object=pure_phase_object and self._object_type == "complex",
             )
 

--- a/py4DSTEM/process/phase/utils.py
+++ b/py4DSTEM/process/phase/utils.py
@@ -203,9 +203,7 @@ class ComplexProbe:
         self, alpha: Union[float, np.ndarray]
     ) -> Union[float, np.ndarray]:
         xp = self._xp
-        return xp.exp(
-            -0.5 * self._gaussian_spread**2 * alpha**2 / self._wavelength**2
-        )
+        return xp.exp(-0.5 * self._gaussian_spread**2 * alpha**2 / self._wavelength**2)
 
     def evaluate_spatial_envelope(
         self, alpha: Union[float, np.ndarray], phi: Union[float, np.ndarray]

--- a/py4DSTEM/process/polar/polar_datacube.py
+++ b/py4DSTEM/process/polar/polar_datacube.py
@@ -4,7 +4,6 @@ from scipy.ndimage import binary_opening, binary_closing, gaussian_filter1d
 
 
 class PolarDatacube:
-
     """
     An interface to a 4D-STEM datacube under polar-elliptical transformation.
     """

--- a/py4DSTEM/process/utils/utils.py
+++ b/py4DSTEM/process/utils/utils.py
@@ -103,12 +103,7 @@ def electron_wavelength_angstrom(E_eV):
     c = 299792458
     h = 6.62607 * 10**-34
 
-    lam = (
-        h
-        / ma.sqrt(2 * m * e * E_eV)
-        / ma.sqrt(1 + e * E_eV / 2 / m / c**2)
-        * 10**10
-    )
+    lam = h / ma.sqrt(2 * m * e * E_eV) / ma.sqrt(1 + e * E_eV / 2 / m / c**2) * 10**10
     return lam
 
 
@@ -117,15 +112,8 @@ def electron_interaction_parameter(E_eV):
     e = 1.602177 * 10**-19
     c = 299792458
     h = 6.62607 * 10**-34
-    lam = (
-        h
-        / ma.sqrt(2 * m * e * E_eV)
-        / ma.sqrt(1 + e * E_eV / 2 / m / c**2)
-        * 10**10
-    )
-    sigma = (
-        (2 * np.pi / lam / E_eV) * (m * c**2 + e * E_eV) / (2 * m * c**2 + e * E_eV)
-    )
+    lam = h / ma.sqrt(2 * m * e * E_eV) / ma.sqrt(1 + e * E_eV / 2 / m / c**2) * 10**10
+    sigma = (2 * np.pi / lam / E_eV) * (m * c**2 + e * E_eV) / (2 * m * c**2 + e * E_eV)
     return sigma
 
 

--- a/py4DSTEM/process/wholepatternfit/wp_models.py
+++ b/py4DSTEM/process/wholepatternfit/wp_models.py
@@ -289,12 +289,16 @@ class GaussianRing(WPFModel):
             "radius": Parameter(radius),
             "sigma": Parameter(sigma),
             "intensity": Parameter(intensity),
-            "x center": WPF.coordinate_model.params["x center"]
-            if global_center
-            else Parameter(x0),
-            "y center": WPF.coordinate_model.params["y center"]
-            if global_center
-            else Parameter(y0),
+            "x center": (
+                WPF.coordinate_model.params["x center"]
+                if global_center
+                else Parameter(x0)
+            ),
+            "y center": (
+                WPF.coordinate_model.params["y center"]
+                if global_center
+                else Parameter(y0)
+            ),
         }
 
         super().__init__(name, params, model_type=WPFModelType.AMORPHOUS)


### PR DESCRIPTION
Previously the BO code retained a reference to the ptycho reconstruction, which in some cases would include a copy of the dataset. This ensures that these resources are released. Additionally it puts `pbar.close()` into a `try/finally` clause so the progressbar is always terminated correctly. 