### PR TITLE
quick fix for probe masking

### DIFF
--- a/docs/papers.md
+++ b/docs/papers.md
@@ -5,57 +5,76 @@
 
 Please email clophus@lbl.gov if you have used py4DSTEM for analysis and your paper is not listed below!
 
-### 2022 (9)
+### 2023 (0)
 
-[Correlative image learning of chemo-mechanics in phase-transforming solids](https://www.nature.com/articles/s41563-021-01191-0), Nature Materials (2022)
 
-[Correlative analysis of structure and chemistry of LixFePO4 platelets using 4D-STEM and X-ray ptychography](https://doi.org/10.1016/j.mattod.2021.10.031), Materials Today 52, 102 (2022).
 
-[Visualizing Grain Statistics in MOCVD WSe2 through Four-Dimensional Scanning Transmission Electron Microscopy](https://doi.org/10.1021/acs.nanolett.1c04315), Nano Letters 22, 2578 (2022).
+### 2022 (16)
 
-[Electric field control of chirality](https://doi.org/10.1126/sciadv.abj8030), Science Advances 8 (2022).
 
-[Real-Time Interactive 4D-STEM Phase-Contrast Imaging From Electron Event Representation Data: Less computation with the right representation](https://doi.org/10.1109/MSP.2021.3120981),  IEEE Signal Processing Magazine 39, 25 (2022).
+[Disentangling multiple scattering with deep learning: application to strain mapping from electron diffraction patterns](https://doi.org/10.1038/s41524-022-00939-9), J Munshi*, A Rakowski*, et al., npj Computational Materials 8, 254 (2022)
 
-[Microstructural dependence of defect formation in iron-oxide thin films](https://doi.org/10.1016/j.apsusc.2022.152844), Applied Surface Science 589, 152844 (2022).
+[Flexible CO2 Sensor Architecture with Selective Nitrogen Functionalities by One-Step Laser-Induced Conversion of Versatile Organic Ink](https://doi.org/10.1002/adfm.202207406), H Wang et al., Advanced Functional Materials 32, 2207406 (2022)
 
-[Chemical and Structural Alterations in the Amorphous Structure of Obsidian due to Nanolites](https://doi.org/10.1017/S1431927621013957), Microscopy and Microanalysis 28, 289 (2022).
+[Defect Contrast with 4D-STEM: Understanding Crystalline Order with Virtual Detectors and Beam Modification](https://doi.org/10.1093/micmic/ozad045) SM Ribet et al., Microscopy and Microanalysis 29, 1087 (2023).
 
-[Nanoscale characterization of crystalline and amorphous phases in silicon oxycarbide ceramics using 4D-STEM](https://doi.org/10.1016/j.matchar.2021.111512), Materials Characterization 181, 111512 (2021).
+[Structural heterogeneity in non-crystalline TexSe1−x thin films](https://doi.org/10.1063/5.0094600), B Sari et al., Applied Physics Letters 121, 012101 (2022)
 
-[Disentangling multiple scattering with deep learning: application to strain mapping from electron diffraction patterns](https://arxiv.org/abs/2202.00204), arXiv:2202.00204 (2022).
+[Cryogenic 4D-STEM analysis of an amorphouscrystalline polymer blend: Combined nanocrystalline and amorphous phase mapping](https://doi.org/10.1016/j.isci.2022.103882), J Donohue et al., iScience 25, 103882 (2022)
+
+[Hydrogen-assisted decohesion associated with nanosized grain boundary κ-carbides in a high-Mn lightweight steel](https://doi.org/10.1016/j.actamat.2022.118392), MN Elkot et al., Acta Materialia
+ 241, 118392 (2022)
+
+[4D-STEM Ptychography for Electron-Beam-Sensitive Materials](https://doi.org/10.1021/acscentsci.2c01137), G Li et al., ACS Central Science 8, 1579 (2022)
+
+[Developing a Chemical and Structural Understanding of the Surface Oxide in a Niobium Superconducting Qubit](https://doi.org/10.1021/acsnano.2c07913), AA Murthy et al., ACS Nano 16, 17257 (2022)
+
+[Correlative image learning of chemo-mechanics in phase-transforming solids](https://www.nature.com/articles/s41563-021-01191-0), HD Deng et al., Nature Materials (2022)
+
+[Correlative analysis of structure and chemistry of LixFePO4 platelets using 4D-STEM and X-ray ptychography](https://doi.org/10.1016/j.mattod.2021.10.031), LA Hughes*, BH Savitzky, et al., Materials Today 52, 102 (2022)
+
+[Visualizing Grain Statistics in MOCVD WSe2 through Four-Dimensional Scanning Transmission Electron Microscopy](https://doi.org/10.1021/acs.nanolett.1c04315), A Londoño-Calderon et al., Nano Letters 22, 2578 (2022)
+
+[Electric field control of chirality](https://doi.org/10.1126/sciadv.abj8030), P Behera et al., Science Advances 8 (2022)
+
+[Real-Time Interactive 4D-STEM Phase-Contrast Imaging From Electron Event Representation Data: Less computation with the right representation](https://doi.org/10.1109/MSP.2021.3120981), P Pelz et al., IEEE Signal Processing Magazine 39, 25 (2022)
+
+[Microstructural dependence of defect formation in iron-oxide thin films](https://doi.org/10.1016/j.apsusc.2022.152844), BK Derby et al., Applied Surface Science 589, 152844 (2022)
+
+[Chemical and Structural Alterations in the Amorphous Structure of Obsidian due to Nanolites](https://doi.org/10.1017/S1431927621013957), E Kennedy et al., Microscopy and Microanalysis 28, 289 (2022)
+
+[Nanoscale characterization of crystalline and amorphous phases in silicon oxycarbide ceramics using 4D-STEM](https://doi.org/10.1016/j.matchar.2021.111512), Ni Yang et al., Materials Characterization 181, 111512 (2021)
 
 
 
 ### 2021 (10)
 
-[Cryoforged nanotwinned titanium with ultrahigh strength and ductility](https://doi.org/10.1126/science.abe7252), Science 16, 373, 1363 (2021).
+[Cryoforged nanotwinned titanium with ultrahigh strength and ductility](https://doi.org/10.1126/science.abe7252), Science 16, 373, 1363 (2021)
 
-[Strain fields in twisted bilayer graphene](https://doi.org/10.1038/s41563-021-00973-w), Nature Materials 20, 956 (2021).
+[Strain fields in twisted bilayer graphene](https://doi.org/10.1038/s41563-021-00973-w), Nature Materials 20, 956 (2021)
 
-[Determination of Grain-Boundary Structure and Electrostatic Characteristics in a SrTiO3 Bicrystal by Four-Dimensional Electron Microscopy](https://doi.org/10.1021/acs.nanolett.1c02960), Nanoletters 21, 9138 (2021).
+[Determination of Grain-Boundary Structure and Electrostatic Characteristics in a SrTiO3 Bicrystal by Four-Dimensional Electron Microscopy](https://doi.org/10.1021/acs.nanolett.1c02960), Nanoletters 21, 9138 (2021)
 
 [Local Lattice Deformation of Tellurene Grain Boundaries by Four-Dimensional Electron Microscopy](https://pubs.acs.org/doi/10.1021/acs.jpcc.1c00308), Journal of Physical Chemistry C 125, 3396 (2021).
 
-[Extreme mixing in nanoscale transition metal alloys](https://doi.org/10.1016/j.matt.2021.04.014), Matter 4, 2340 (2021).
+[Extreme mixing in nanoscale transition metal alloys](https://doi.org/10.1016/j.matt.2021.04.014), Matter 4, 2340 (2021)
 
-[Multibeam Electron Diffraction](https://doi.org/10.1017/S1431927620024770), Microscopy and Microanalysis 27, 129 (2021).
+[Multibeam Electron Diffraction](https://doi.org/10.1017/S1431927620024770), Microscopy and Microanalysis 27, 129 (2021)
 
-[A Fast Algorithm for Scanning Transmission Electron Microscopy Imaging and 4D-STEM Diffraction Simulations](https://doi.org/10.1017/S1431927621012083), Microscopy and Microanalysis 27, 835 (2021).
+[A Fast Algorithm for Scanning Transmission Electron Microscopy Imaging and 4D-STEM Diffraction Simulations](https://doi.org/10.1017/S1431927621012083), Microscopy and Microanalysis 27, 835 (2021)
 
-[Fast Grain Mapping with Sub-Nanometer Resolution Using 4D-STEM with Grain Classification by Principal Component Analysis and Non-Negative Matrix Factorization](https://doi.org/10.1017/S1431927621011946), Microscopy and Microanalysis 27, 794
+[Fast Grain Mapping with Sub-Nanometer Resolution Using 4D-STEM with Grain Classification by Principal Component Analysis and Non-Negative Matrix Factorization](https://doi.org/10.1017/S1431927621011946), Microscopy and Microanalysis 27, 794 (2021)
 
-[Prismatic 2.0 – Simulation software for scanning and high resolution transmission electron microscopy (STEM and HRTEM)](https://doi.org/10.1016/j.micron.2021.103141), Micron 151, 103141 (2021).
+[Prismatic 2.0 – Simulation software for scanning and high resolution transmission electron microscopy (STEM and HRTEM)](https://doi.org/10.1016/j.micron.2021.103141), Micron 151, 103141 (2021)
 
-[4D-STEM of Beam-Sensitive Materials](https://doi.org/10.1021/acs.accounts.1c00073), Accounts of Chemical Research 54, 2543 (2021).
+[4D-STEM of Beam-Sensitive Materials](https://doi.org/10.1021/acs.accounts.1c00073), Accounts of Chemical Research 54, 2543 (2021)
 
 
 ### 2020 (3)
 
-[Patterned probes for high precision 4D-STEM bragg measurements](https://doi.org/10.1063/5.0015532), Ultramicroscopy 209, 112890 (2020).
+[Patterned probes for high precision 4D-STEM bragg measurements](https://doi.org/10.1063/5.0015532), Ultramicroscopy 209, 112890 (2020)
 
-
-[Tilted fluctuation electron microscopy](https://doi.org/10.1063/5.0015532), Applied Physics Letters 117, 091903 (2020).
+[Tilted fluctuation electron microscopy](https://doi.org/10.1063/5.0015532), Applied Physics Letters 117, 091903 (2020)
 
 [4D-STEM elastic stress state characterisation of a TWIP steel nanotwin](https://arxiv.org/abs/2004.03982), arXiv:2004.03982
 

--- a/py4DSTEM/datacube/datacube.py
+++ b/py4DSTEM/datacube/datacube.py
@@ -510,7 +510,7 @@ class DataCube(
         ROI=None,
         align=True,
         mask=None,
-        threshold=0.2,
+        threshold=0.0,
         expansion=12,
         opening=3,
         verbose=False,

--- a/py4DSTEM/process/polar/polar_fits.py
+++ b/py4DSTEM/process/polar/polar_fits.py
@@ -3,15 +3,18 @@ import matplotlib.pyplot as plt
 
 # from scipy.optimize import leastsq
 from scipy.optimize import curve_fit
+from emdfile import tqdmnd
 
 
 def fit_amorphous_ring(
-    im,
+    im = None,
+    datacube = None,
     center=None,
     radial_range=None,
     coefs=None,
     mask_dp=None,
     show_fit_mask=False,
+    fit_all_images = False,
     maxfev=None,
     verbose=False,
     plot_result=True,
@@ -19,6 +22,7 @@ def fit_amorphous_ring(
     plot_int_scale=(-3, 3),
     figsize=(8, 8),
     return_all_coefs=True,
+    progress_bar = None,
 ):
     """
     Fit an amorphous halo with a two-sided Gaussian model, plus a background
@@ -28,6 +32,8 @@ def fit_amorphous_ring(
     --------
     im: np.array
         2D image array to perform fitting on
+    datacube: py4DSTEM.DataCube
+        datacube to perform the fitting on
     center: np.array
         (x,y) center coordinates for fitting mask. If not specified
         by the user, we will assume the center coordinate is (im.shape-1)/2.
@@ -40,6 +46,8 @@ def fit_amorphous_ring(
         Dark field mask for fitting, in addition to the radial range specified above.
     show_fit_mask: bool
         Set to true to preview the fitting mask and initial guess for the ellipse params
+    fit_all_images: bool
+        Fit the elliptic parameters to all images
     maxfev: int
         Max number of fitting evaluations for curve_fit.
     verbose: bool
@@ -62,6 +70,13 @@ def fit_amorphous_ring(
     params_ellipse_fit: np.array (optional)
         11 parameter elliptic fit coefficients
     """
+
+    # If passing in a DataCube, use mean diffraction pattern for initial guess
+    if im is None:
+        im = datacube.get_dp_mean()
+        if progress_bar is None:
+            progress_bar = True
+    
 
     # Default values
     if center is None:
@@ -193,7 +208,49 @@ def fit_amorphous_ring(
             )[0]
         coefs[4] = np.mod(coefs[4], 2 * np.pi)
         coefs[5:8] *= int_mean
-        # bounds=bounds
+
+        # Perform the fit on each individual diffration pattern
+        if fit_all_images:
+            coefs_all = np.zeros((
+                datacube.shape[0],
+                datacube.shape[1],
+                coefs.size))
+            
+            for rx, ry in tqdmnd(
+                datacube.shape[0],
+                datacube.shape[1],
+                desc="Radial statistics",
+                unit=" probe positions",
+                disable=not progress_bar,
+            ):
+                vals = datacube.data[rx,ry][mask]
+                int_mean = np.mean(vals)
+
+                if maxfev is None:
+                    coefs_single = curve_fit(
+                        amorphous_model,
+                        basis,
+                        vals / int_mean,
+                        p0=coefs,
+                        xtol=1e-8,
+                        bounds=(lb, ub),
+                    )[0]
+                else:
+                    coefs_single = curve_fit(
+                        amorphous_model,
+                        basis,
+                        vals / int_mean,
+                        p0=coefs,
+                        xtol=1e-8,
+                        bounds=(lb, ub),
+                        maxfev=maxfev,
+                    )[0]
+                coefs_single[4] = np.mod(coefs_single[4], 2 * np.pi)
+                coefs_single[5:8] *= int_mean
+
+                coefs_all[rx,ry] = coefs_single
+
+
 
     if verbose:
         print("x0 = " + str(np.round(coefs[0], 3)) + " px")
@@ -214,9 +271,15 @@ def fit_amorphous_ring(
 
     # Return fit parameters
     if return_all_coefs:
-        return coefs
+        if fit_all_images:
+            return coefs_all
+        else:
+            return coefs
     else:
-        return coefs[:5]
+        if fit_all_images:
+            return coefs_all[:,:,:5]
+        else:
+            return coefs[:5]
 
 
 def plot_amorphous_ring(

--- a/py4DSTEM/process/polar/polar_fits.py
+++ b/py4DSTEM/process/polar/polar_fits.py
@@ -7,14 +7,14 @@ from emdfile import tqdmnd
 
 
 def fit_amorphous_ring(
-    im = None,
-    datacube = None,
+    im=None,
+    datacube=None,
     center=None,
     radial_range=None,
     coefs=None,
     mask_dp=None,
     show_fit_mask=False,
-    fit_all_images = False,
+    fit_all_images=False,
     maxfev=None,
     verbose=False,
     plot_result=True,
@@ -22,7 +22,7 @@ def fit_amorphous_ring(
     plot_int_scale=(-3, 3),
     figsize=(8, 8),
     return_all_coefs=True,
-    progress_bar = None,
+    progress_bar=None,
 ):
     """
     Fit an amorphous halo with a two-sided Gaussian model, plus a background
@@ -76,7 +76,6 @@ def fit_amorphous_ring(
         im = datacube.get_dp_mean()
         if progress_bar is None:
             progress_bar = True
-    
 
     # Default values
     if center is None:
@@ -211,11 +210,8 @@ def fit_amorphous_ring(
 
         # Perform the fit on each individual diffration pattern
         if fit_all_images:
-            coefs_all = np.zeros((
-                datacube.shape[0],
-                datacube.shape[1],
-                coefs.size))
-            
+            coefs_all = np.zeros((datacube.shape[0], datacube.shape[1], coefs.size))
+
             for rx, ry in tqdmnd(
                 datacube.shape[0],
                 datacube.shape[1],
@@ -223,7 +219,7 @@ def fit_amorphous_ring(
                 unit=" probe positions",
                 disable=not progress_bar,
             ):
-                vals = datacube.data[rx,ry][mask]
+                vals = datacube.data[rx, ry][mask]
                 int_mean = np.mean(vals)
 
                 if maxfev is None:
@@ -248,9 +244,7 @@ def fit_amorphous_ring(
                 coefs_single[4] = np.mod(coefs_single[4], 2 * np.pi)
                 coefs_single[5:8] *= int_mean
 
-                coefs_all[rx,ry] = coefs_single
-
-
+                coefs_all[rx, ry] = coefs_single
 
     if verbose:
         print("x0 = " + str(np.round(coefs[0], 3)) + " px")
@@ -277,7 +271,7 @@ def fit_amorphous_ring(
             return coefs
     else:
         if fit_all_images:
-            return coefs_all[:,:,:5]
+            return coefs_all[:, :, :5]
         else:
             return coefs[:5]
 


### PR DESCRIPTION
The default threshold for the probe intensity was 0.2 - this fails for counted data where the intensity is <<1.  The default should be 0.0, especially if we are providing a mask in diffraction space.