### PR TITLE
Phase contrast quality of life improvements

### DIFF
--- a/py4DSTEM/process/phase/magnetic_ptychographic_tomography.py
+++ b/py4DSTEM/process/phase/magnetic_ptychographic_tomography.py
@@ -225,6 +225,7 @@ class MagneticPtychographicTomography(
         padded_diffraction_intensities_shape: Tuple[int, int] = None,
         region_of_interest_shape: Tuple[int, int] = None,
         dp_mask: np.ndarray = None,
+        in_place_datacube_modification: bool = False,
         fit_function: str = "plane",
         plot_probe_overlaps: bool = True,
         rotation_real_space_degrees: float = None,
@@ -266,6 +267,9 @@ class MagneticPtychographicTomography(
             at the diffraction plane to allow comparison with experimental data
         dp_mask: ndarray, optional
             Mask for datacube intensities (Qx,Qy)
+        in_place_datacube_modification: bool, optional
+            If True, the datacube will be preprocessed in-place. Note this is not possible
+            when either crop_patterns or positions_mask are used.
         fit_function: str, optional
             2D fitting function for CoM fitting. One of 'plane','parabola','bezier_two'
         plot_probe_overlaps: bool, optional
@@ -479,12 +483,14 @@ class MagneticPtychographicTomography(
                 amplitudes,
                 mean_diffraction_intensity_temp,
                 self._crop_mask,
+                self._crop_mask_shape,
             ) = self._normalize_diffraction_intensities(
                 intensities,
                 com_fitted_x,
                 com_fitted_y,
                 self._positions_mask[index],
                 crop_patterns,
+                in_place_datacube_modification,
             )
 
             self._mean_diffraction_intensity.append(mean_diffraction_intensity_temp)

--- a/py4DSTEM/process/phase/magnetic_ptychography.py
+++ b/py4DSTEM/process/phase/magnetic_ptychography.py
@@ -377,10 +377,6 @@ class MagneticPtychography(
                 f"datacube must be the same length as magnetic_contribution_sign, not length {len(self._datacube)}."
             )
 
-        dc_shapes = [dc.shape for dc in self._datacube]
-        if dc_shapes.count(dc_shapes[0]) != self._num_measurements:
-            raise ValueError("datacube intensities must be the same size.")
-
         if self._positions_mask is not None:
             self._positions_mask = np.asarray(self._positions_mask, dtype="bool")
 

--- a/py4DSTEM/process/phase/magnetic_ptychography.py
+++ b/py4DSTEM/process/phase/magnetic_ptychography.py
@@ -208,6 +208,7 @@ class MagneticPtychography(
         padded_diffraction_intensities_shape: Tuple[int, int] = None,
         region_of_interest_shape: Tuple[int, int] = None,
         dp_mask: np.ndarray = None,
+        in_place_datacube_modification: bool = False,
         fit_function: str = "plane",
         plot_rotation: bool = True,
         maximize_divergence: bool = False,
@@ -259,6 +260,9 @@ class MagneticPtychography(
             at the diffraction plane to allow comparison with experimental data
         dp_mask: ndarray, optional
             Mask for datacube intensities (Qx,Qy)
+        in_place_datacube_modification: bool, optional
+            If True, the datacube will be preprocessed in-place. Note this is not possible
+            when either crop_patterns or positions_mask are used.
         fit_function: str, optional
             2D fitting function for CoM fitting. One of 'plane','parabola','bezier_two'
         plot_rotation: bool, optional
@@ -551,12 +555,14 @@ class MagneticPtychography(
                 amplitudes,
                 mean_diffraction_intensity_temp,
                 self._crop_mask,
+                self._crop_mask_shape,
             ) = self._normalize_diffraction_intensities(
                 intensities,
                 com_fitted_x,
                 com_fitted_y,
                 self._positions_mask[index],
                 crop_patterns,
+                in_place_datacube_modification,
             )
 
             self._mean_diffraction_intensity.append(mean_diffraction_intensity_temp)

--- a/py4DSTEM/process/phase/mixedstate_multislice_ptychography.py
+++ b/py4DSTEM/process/phase/mixedstate_multislice_ptychography.py
@@ -267,6 +267,7 @@ class MixedstateMultislicePtychography(
         padded_diffraction_intensities_shape: Tuple[int, int] = None,
         region_of_interest_shape: Tuple[int, int] = None,
         dp_mask: np.ndarray = None,
+        in_place_datacube_modification: bool = False,
         fit_function: str = "plane",
         plot_center_of_mass: str = "default",
         plot_rotation: bool = True,
@@ -318,6 +319,9 @@ class MixedstateMultislicePtychography(
             at the diffraction plane to allow comparison with experimental data
         dp_mask: ndarray, optional
             Mask for datacube intensities (Qx,Qy)
+        in_place_datacube_modification: bool, optional
+            If True, the datacube will be preprocessed in-place. Note this is not possible
+            when either crop_patterns or positions_mask are used.
         fit_function: str, optional
             2D fitting function for CoM fitting. One of 'plane','parabola','bezier_two'
         plot_center_of_mass: str, optional
@@ -486,17 +490,21 @@ class MixedstateMultislicePtychography(
             self._amplitudes,
             self._mean_diffraction_intensity,
             self._crop_mask,
+            self._crop_mask_shape,
         ) = self._normalize_diffraction_intensities(
             _intensities,
             self._com_fitted_x,
             self._com_fitted_y,
             self._positions_mask,
             crop_patterns,
+            in_place_datacube_modification,
         )
 
         # explicitly transfer arrays to storage
+        if not in_place_datacube_modification:
+            del _intensities
+
         self._amplitudes = copy_to_device(self._amplitudes, storage)
-        del _intensities
 
         self._num_diffraction_patterns = self._amplitudes.shape[0]
         self._amplitudes_shape = np.array(self._amplitudes.shape[-2:])

--- a/py4DSTEM/process/phase/mixedstate_ptychography.py
+++ b/py4DSTEM/process/phase/mixedstate_ptychography.py
@@ -213,6 +213,7 @@ class MixedstatePtychography(
         padded_diffraction_intensities_shape: Tuple[int, int] = None,
         region_of_interest_shape: Tuple[int, int] = None,
         dp_mask: np.ndarray = None,
+        in_place_datacube_modification: bool = False,
         fit_function: str = "plane",
         plot_center_of_mass: str = "default",
         plot_rotation: bool = True,
@@ -264,6 +265,9 @@ class MixedstatePtychography(
             at the diffraction plane to allow comparison with experimental data
         dp_mask: ndarray, optional
             Mask for datacube intensities (Qx,Qy)
+        in_place_datacube_modification: bool, optional
+            If True, the datacube will be preprocessed in-place. Note this is not possible
+            when either crop_patterns or positions_mask are used.
         fit_function: str, optional
             2D fitting function for CoM fitting. One of 'plane','parabola','bezier_two'
         plot_center_of_mass: str, optional
@@ -432,17 +436,21 @@ class MixedstatePtychography(
             self._amplitudes,
             self._mean_diffraction_intensity,
             self._crop_mask,
+            self._crop_mask_shape,
         ) = self._normalize_diffraction_intensities(
             _intensities,
             self._com_fitted_x,
             self._com_fitted_y,
             self._positions_mask,
             crop_patterns,
+            in_place_datacube_modification,
         )
 
         # explicitly transfer arrays to storage
+        if not in_place_datacube_modification:
+            del _intensities
+
         self._amplitudes = copy_to_device(self._amplitudes, storage)
-        del _intensities
 
         self._num_diffraction_patterns = self._amplitudes.shape[0]
         self._amplitudes_shape = np.array(self._amplitudes.shape[-2:])

--- a/py4DSTEM/process/phase/multislice_ptychography.py
+++ b/py4DSTEM/process/phase/multislice_ptychography.py
@@ -241,6 +241,7 @@ class MultislicePtychography(
         padded_diffraction_intensities_shape: Tuple[int, int] = None,
         region_of_interest_shape: Tuple[int, int] = None,
         dp_mask: np.ndarray = None,
+        in_place_datacube_modification: bool = False,
         fit_function: str = "plane",
         plot_center_of_mass: str = "default",
         plot_rotation: bool = True,
@@ -292,6 +293,9 @@ class MultislicePtychography(
             at the diffraction plane to allow comparison with experimental data
         dp_mask: ndarray, optional
             Mask for datacube intensities (Qx,Qy)
+        in_place_datacube_modification: bool, optional
+            If True, the datacube will be preprocessed in-place. Note this is not possible
+            when either crop_patterns or positions_mask are used.
         fit_function: str, optional
             2D fitting function for CoM fitting. One of 'plane','parabola','bezier_two'
         plot_center_of_mass: str, optional
@@ -460,17 +464,21 @@ class MultislicePtychography(
             self._amplitudes,
             self._mean_diffraction_intensity,
             self._crop_mask,
+            self._crop_mask_shape,
         ) = self._normalize_diffraction_intensities(
             _intensities,
             self._com_fitted_x,
             self._com_fitted_y,
             self._positions_mask,
             crop_patterns,
+            in_place_datacube_modification,
         )
 
         # explicitly transfer arrays to storage
+        if not in_place_datacube_modification:
+            del _intensities
+
         self._amplitudes = copy_to_device(self._amplitudes, storage)
-        del _intensities
 
         self._num_diffraction_patterns = self._amplitudes.shape[0]
         self._amplitudes_shape = np.array(self._amplitudes.shape[-2:])

--- a/py4DSTEM/process/phase/parallax.py
+++ b/py4DSTEM/process/phase/parallax.py
@@ -291,12 +291,15 @@ class Parallax(PhaseReconstruction):
         defocus_guess: float, optional
             Initial guess of defocus value (defocus dF) in A
             If None, first iteration is assumed to be in-focus
+        aligned_bf_image_guess: np.ndarray, optional
+            Guess for the reference BF image to cross-correlate against during the first iteration
+            If None, the incoherent BF image is used instead.
+        rotation_guess: float, optional
+            Initial guess of rotation value in degrees
+            If None, first iteration assumed to be 0
         descan_correction_fit_function: str, optional
             If not None, descan correction will be performed using fit function.
             One of "constant", "plane", "parabola", or "bezier_two".
-        rotation_guess: float, optional
-            Initial guess of defocus value in degrees
-            If None, first iteration assumed to be 0
         plot_average_bf: bool, optional
             If True, plots the average bright field image, using defocus_guess
         realspace_mask: np.array, optional
@@ -794,7 +797,44 @@ class Parallax(PhaseReconstruction):
         scale_arrows=1,
         **kwargs,
     ):
-        """ """
+        """
+        Generates analytical BF shifts and uses them to align the virtual BF stack,
+        based on the experimental geometry (rotation, transpose), and common aberrations.
+
+        Parameters
+        ----------
+        rotation_angle_deg: float, optional
+            Relative rotation between the scan and the diffraction space coordinate systems
+        transpose: bool, optional
+            Whether the diffraction intensities are transposed
+        kde_upsample_factor: int, optional
+            Real-space upsampling factor
+        kde_sigma_px: float, optional
+            KDE gaussian kernel bandwidth in non-upsampled pixels
+        kde_lowpass_filter: bool, optional
+            If True, the resulting KDE upsampled image is lowpass-filtered using a sinc-function
+        lanczos_interpolation_order: int, optional
+            If not None, Lanczos interpolation with the specified order is used instead of bilinear
+        defocus: float, optional
+            Defocus value to use in computing analytical BF shifts
+        astigmatism: float, optional
+            Astigmatism value to use in computing analytical BF shifts
+        astigmatism_angle_deg: float, optional
+            Astigmatism angle to use in computing analytical BF shifts
+        coma: float, optional
+            Coma value to use in computing analytical BF shifts
+        coma_angle_deg: float, optional
+            Coma angle to use in computing analytical BF shifts
+        spherical_aberration: float, optional
+            Spherical aberration value to use in computing analytical BF shifts
+        max_batch_size: int, optional
+            Max number of virtual BF images to use at once in computing cross-correlation
+        plot_arrow_freq: int, optional
+            Frequency of shifts to plot in quiver plot
+        scale_arrows: float, optional
+            Scale to multiply shifts by
+
+        """
         xp = self._xp
         asnumpy = self._asnumpy
 

--- a/py4DSTEM/process/phase/parallax.py
+++ b/py4DSTEM/process/phase/parallax.py
@@ -19,6 +19,7 @@ from py4DSTEM.process.phase.utils import (
     AffineTransform,
     bilinear_kernel_density_estimate,
     bilinearly_interpolate_array,
+    calculate_aberration_gradient_basis,
     generate_batches,
     lanczos_interpolate_array,
     lanczos_kernel_density_estimate,
@@ -26,7 +27,7 @@ from py4DSTEM.process.phase.utils import (
 )
 from py4DSTEM.process.utils.cross_correlate import align_images_fourier
 from py4DSTEM.process.utils.utils import electron_wavelength_angstrom
-from py4DSTEM.visualize import return_scaled_histogram_ordering, show
+from py4DSTEM.visualize import return_scaled_histogram_ordering
 from scipy.linalg import polar
 from scipy.ndimage import distance_transform_edt
 from scipy.optimize import minimize
@@ -287,7 +288,6 @@ class Parallax(PhaseReconstruction):
             If True, bright images normalized to have a mean of 1
         normalize_order: integer, optional
             Polynomial order for normalization. 0 means constant, 1 means linear, etc.
-            Higher orders not yet implemented.
         defocus_guess: float, optional
             Initial guess of defocus value (defocus dF) in A
             If None, first iteration is assumed to be in-focus
@@ -774,6 +774,142 @@ class Parallax(PhaseReconstruction):
         self.clear_device_mem(self._device, self._clear_fft_cache)
 
         return self
+
+    def guess_common_aberrations_and_rotation(
+        self,
+        rotation_angle_deg=0,
+        defocus=0,
+        astigmatism=0,
+        astigmatism_angle_deg=0,
+        coma=0,
+        coma_angle_deg=0,
+        spherical_aberration=0,
+        max_batch_size=None,
+        plot_arrow_freq=1,
+        scale_arrows=1,
+        **kwargs,
+    ):
+        """ """
+        xp = self._xp
+        asnumpy = self._asnumpy
+
+        if not hasattr(self, "_recon_BF"):
+            raise ValueError(
+                (
+                    "Aberration guessing is meant to be ran after preprocessing. "
+                    "Please run the `preprocess()` function first."
+                )
+            )
+
+        # aberrations_coefs
+        aberrations_mn = [
+            [1, 0, 0],
+            [1, 2, 0],
+            [1, 2, 1],
+            [2, 1, 0],
+            [2, 1, 1],
+            [3, 0, 0],
+        ]
+        astigmatism_x = astigmatism * np.cos(np.deg2rad(astigmatism_angle_deg) * 2)
+        astigmatism_y = astigmatism * np.sin(np.deg2rad(astigmatism_angle_deg) * 2)
+        coma_x = coma * np.cos(np.deg2rad(coma_angle_deg) * 1)
+        coma_y = coma * np.sin(np.deg2rad(coma_angle_deg) * 1)
+        aberrations_coefs = xp.array(
+            [
+                -defocus,
+                astigmatism_x,
+                astigmatism_y,
+                coma_x,
+                coma_y,
+                spherical_aberration,
+            ]
+        )
+
+        # aberrations_basis
+        sampling = 1 / (
+            np.array(self._reciprocal_sampling) * self._region_of_interest_shape
+        )
+        aberrations_basis, aberrations_basis_du, aberrations_basis_dv = (
+            calculate_aberration_gradient_basis(
+                aberrations_mn,
+                sampling,
+                self._region_of_interest_shape,
+                self._wavelength,
+                rotation_angle=np.deg2rad(rotation_angle_deg),
+                xp=xp,
+            )
+        )
+
+        # shifts
+        corner_indices = self._xy_inds - xp.array(self._region_of_interest_shape // 2)
+        raveled_indices = xp.ravel_multi_index(
+            corner_indices.T, self._region_of_interest_shape, mode="wrap"
+        )
+        gradients = xp.array(
+            (
+                aberrations_basis_du[raveled_indices, :],
+                aberrations_basis_dv[raveled_indices, :],
+            )
+        )
+        shifts_ang = xp.tensordot(gradients, aberrations_coefs, axes=1).T
+        shifts_px = shifts_ang / xp.array(self._scan_sampling)
+
+        # shifted stack
+        aligned_stack = xp.zeros_like(self._stack_BF_shifted_initial[0])
+        if max_batch_size is None:
+            max_batch_size = self._num_bf_images
+
+        for start, end in generate_batches(
+            self._num_bf_images, max_batch=max_batch_size
+        ):
+            shifted_BFs = self._stack_BF_shifted_initial[start:end]
+
+            Gs = xp.fft.fft2(shifted_BFs)
+
+            dx = shifts_px[start:end, 0]
+            dy = shifts_px[start:end, 1]
+
+            shift_op = xp.exp(
+                self._qx_shift[None] * dx[:, None, None]
+                + self._qy_shift[None] * dy[:, None, None]
+            )
+            stack_BF_shifted = xp.real(xp.fft.ifft2(Gs * shift_op))
+            aligned_stack += stack_BF_shifted.sum(0)
+
+        cropped_stack = asnumpy(
+            self._crop_padded_object(aligned_stack, upsampled=False)
+        )
+
+        figsize = kwargs.pop("figsize", (8, 4))
+        color = kwargs.pop("color", (1, 0, 0, 1))
+        cmap = kwargs.pop("cmap", "magma")
+
+        fig, axs = plt.subplots(1, 2, figsize=figsize)
+
+        self.show_shifts(
+            shifts_ang=shifts_ang,
+            plot_arrow_freq=plot_arrow_freq,
+            scale_arrows=scale_arrows,
+            plot_rotated_shifts=False,
+            color=color,
+            figax=(fig, axs[0]),
+        )
+
+        axs[0].set_title("Predicted BF Shifts")
+
+        extent = [
+            0,
+            self._scan_sampling[1] * cropped_stack.shape[1],
+            self._scan_sampling[0] * cropped_stack.shape[0],
+            0,
+        ]
+
+        axs[1].imshow(cropped_stack, cmap=cmap, extent=extent, **kwargs)
+        axs[1].set_ylabel("x [A]")
+        axs[1].set_xlabel("y [A]")
+        axs[1].set_title("Predicted Aligned BF Image")
+
+        fig.tight_layout()
 
     def reconstruct(
         self,
@@ -2092,75 +2228,21 @@ class Parallax(PhaseReconstruction):
 
         # Direct Shifts Fitting
         if fit_BF_shifts:
-            # FFT coordinates
-            sx = 1 / (self._reciprocal_sampling[0] * self._region_of_interest_shape[0])
-            sy = 1 / (self._reciprocal_sampling[1] * self._region_of_interest_shape[1])
-            qx = xp.fft.fftfreq(self._region_of_interest_shape[0], sx)
-            qy = xp.fft.fftfreq(self._region_of_interest_shape[1], sy)
-            qx, qy = np.meshgrid(qx, qy, indexing="ij")
-
-            # passive rotation basis by -theta
-            rotation_angle = -self.rotation_Q_to_R_rads
-            qx, qy = qx * np.cos(rotation_angle) + qy * np.sin(
-                rotation_angle
-            ), -qx * np.sin(rotation_angle) + qy * np.cos(rotation_angle)
-
-            qr2 = qx**2 + qy**2
-            u = qx * self._wavelength
-            v = qy * self._wavelength
-            alpha = xp.sqrt(qr2) * self._wavelength
-            theta = xp.arctan2(qy, qx)
-
-            # Aberration basis
-            self._aberrations_basis = xp.zeros((alpha.size, self._aberrations_num))
-            self._aberrations_basis_du = xp.zeros((alpha.size, self._aberrations_num))
-            self._aberrations_basis_dv = xp.zeros((alpha.size, self._aberrations_num))
-            for a0 in range(self._aberrations_num):
-                m, n, a = self._aberrations_mn[a0]
-
-                if n == 0:
-                    # Radially symmetric basis
-                    self._aberrations_basis[:, a0] = (
-                        alpha ** (m + 1) / (m + 1)
-                    ).ravel()
-                    self._aberrations_basis_du[:, a0] = (u * alpha ** (m - 1)).ravel()
-                    self._aberrations_basis_dv[:, a0] = (v * alpha ** (m - 1)).ravel()
-
-                elif a == 0:
-                    # cos coef
-                    self._aberrations_basis[:, a0] = (
-                        alpha ** (m + 1) * xp.cos(n * theta) / (m + 1)
-                    ).ravel()
-                    self._aberrations_basis_du[:, a0] = (
-                        alpha ** (m - 1)
-                        * ((m + 1) * u * xp.cos(n * theta) + n * v * xp.sin(n * theta))
-                        / (m + 1)
-                    ).ravel()
-                    self._aberrations_basis_dv[:, a0] = (
-                        alpha ** (m - 1)
-                        * ((m + 1) * v * xp.cos(n * theta) - n * u * xp.sin(n * theta))
-                        / (m + 1)
-                    ).ravel()
-
-                else:
-                    # sin coef
-                    self._aberrations_basis[:, a0] = (
-                        alpha ** (m + 1) * xp.sin(n * theta) / (m + 1)
-                    ).ravel()
-                    self._aberrations_basis_du[:, a0] = (
-                        alpha ** (m - 1)
-                        * ((m + 1) * u * xp.sin(n * theta) - n * v * xp.cos(n * theta))
-                        / (m + 1)
-                    ).ravel()
-                    self._aberrations_basis_dv[:, a0] = (
-                        alpha ** (m - 1)
-                        * ((m + 1) * v * xp.sin(n * theta) + n * u * xp.cos(n * theta))
-                        / (m + 1)
-                    ).ravel()
-
-            # global scaling
-            self._aberrations_basis *= 2 * np.pi / self._wavelength
-            self._aberrations_surface_shape = alpha.shape
+            sampling = 1 / (
+                np.array(self._reciprocal_sampling) * self._region_of_interest_shape
+            )
+            (
+                self._aberrations_babis,
+                self._aberrations_basis_du,
+                self._aberrations_basis_dv,
+            ) = calculate_aberration_gradient_basis(
+                self._aberrations_mn,
+                sampling,
+                self._region_of_interest_shape,
+                self._wavelength,
+                rotation_angle=self.rotation_Q_to_R_rads,
+                xp=xp,
+            )
 
             # CTF function
             def calculate_CTF(alpha_shape, *coefs):

--- a/py4DSTEM/process/phase/parallax.py
+++ b/py4DSTEM/process/phase/parallax.py
@@ -793,6 +793,8 @@ class Parallax(PhaseReconstruction):
         coma_angle_deg=0,
         spherical_aberration=0,
         max_batch_size=None,
+        plot_shifts_and_aligned_bf=True,
+        return_shifts_and_aligned_bf=False,
         plot_arrow_freq=1,
         scale_arrows=1,
         **kwargs,
@@ -829,6 +831,10 @@ class Parallax(PhaseReconstruction):
             Spherical aberration value to use in computing analytical BF shifts
         max_batch_size: int, optional
             Max number of virtual BF images to use at once in computing cross-correlation
+        plot_shifts_and_aligned_bf: bool, optional
+            If True, the analytical shifts and the aligned virtual VF image are plotted
+        return_shifts_and_aligned_bf: bool, optional
+            If True, the analytical shifts and the aligned virtual VF image are returned
         plot_arrow_freq: int, optional
             Frequency of shifts to plot in quiver plot
         scale_arrows: float, optional
@@ -971,36 +977,40 @@ class Parallax(PhaseReconstruction):
                 self._crop_padded_object(aligned_stack, upsampled=False)
             )
 
-        figsize = kwargs.pop("figsize", (8, 4))
-        color = kwargs.pop("color", (1, 0, 0, 1))
-        cmap = kwargs.pop("cmap", "magma")
+        if plot_shifts_and_aligned_bf:
+            figsize = kwargs.pop("figsize", (8, 4))
+            color = kwargs.pop("color", (1, 0, 0, 1))
+            cmap = kwargs.pop("cmap", "magma")
 
-        fig, axs = plt.subplots(1, 2, figsize=figsize)
+            fig, axs = plt.subplots(1, 2, figsize=figsize)
 
-        self.show_shifts(
-            shifts_ang=shifts_ang,
-            plot_arrow_freq=plot_arrow_freq,
-            scale_arrows=scale_arrows,
-            plot_rotated_shifts=False,
-            color=color,
-            figax=(fig, axs[0]),
-        )
+            self.show_shifts(
+                shifts_ang=shifts_ang,
+                plot_arrow_freq=plot_arrow_freq,
+                scale_arrows=scale_arrows,
+                plot_rotated_shifts=False,
+                color=color,
+                figax=(fig, axs[0]),
+            )
 
-        axs[0].set_title("Predicted BF Shifts")
+            axs[0].set_title("Predicted BF Shifts")
 
-        extent = [
-            0,
-            self._scan_sampling[1] * cropped_image.shape[1] / kde_upsample_factor,
-            self._scan_sampling[0] * cropped_image.shape[0] / kde_upsample_factor,
-            0,
-        ]
+            extent = [
+                0,
+                self._scan_sampling[1] * cropped_image.shape[1] / kde_upsample_factor,
+                self._scan_sampling[0] * cropped_image.shape[0] / kde_upsample_factor,
+                0,
+            ]
 
-        axs[1].imshow(cropped_image, cmap=cmap, extent=extent, **kwargs)
-        axs[1].set_ylabel("x [A]")
-        axs[1].set_xlabel("y [A]")
-        axs[1].set_title("Predicted Aligned BF Image")
+            axs[1].imshow(cropped_image, cmap=cmap, extent=extent, **kwargs)
+            axs[1].set_ylabel("x [A]")
+            axs[1].set_xlabel("y [A]")
+            axs[1].set_title("Predicted Aligned BF Image")
 
-        fig.tight_layout()
+            fig.tight_layout()
+
+        if return_shifts_and_aligned_bf:
+            return shifts_ang, cropped_image
 
     def reconstruct(
         self,

--- a/py4DSTEM/process/phase/parameter_optimize.py
+++ b/py4DSTEM/process/phase/parameter_optimize.py
@@ -135,7 +135,7 @@ class PtychographyOptimizer:
 
         Parameters
         ----------
-        n_initial_points: int
+        n_points: int
             Number of uniformly spaced trial points to run on a grid
         error_metric: Callable or str
             Function used to compute the reconstruction error.
@@ -233,7 +233,7 @@ class PtychographyOptimizer:
                 ax.imshow(res[0], cmap=cmap)
 
                 title_substrings = [
-                    f"{param.name}: {val}"
+                    f"{param.name}: {val:.3e}"
                     for param, val in zip(self._parameter_list, params)
                 ]
                 title_substrings.append(f"error: {res[1]:.3e}")
@@ -485,8 +485,10 @@ class PtychographyOptimizer:
             "log-converged",
             "linear-converged",
             "TV",
+            "TV-phase",
             "std",
             "std-phase",
+            "entropy",
             "entropy-phase",
         ), f"Error metric {error_metric} not recognized."
 
@@ -519,10 +521,20 @@ class PtychographyOptimizer:
         elif error_metric == "TV":
 
             def f(ptycho):
-                gx, gy = np.gradient(ptycho.object_cropped, axis=(-2, -1))
-                obj_mag = np.sum(np.abs(ptycho.object_cropped))
+                array = np.abs(ptycho.object_cropped)
+                gx = array[..., 1:, :] - array[..., -1:, :]
+                gy = array[..., :, 1:] - array[..., :, -1:]
                 tv = np.sum(np.abs(gx)) + np.sum(np.abs(gy))
-                return tv / obj_mag
+                return tv / array.size
+
+        elif error_metric == "TV-phase":
+
+            def f(ptycho):
+                array = np.angle(ptycho.object_cropped)
+                gx = array[..., 1:, :] - array[..., -1:, :]
+                gy = array[..., :, 1:] - array[..., :, -1:]
+                tv = np.sum(np.abs(gx)) + np.sum(np.abs(gy))
+                return tv / array.size
 
         elif error_metric == "std":
 
@@ -534,16 +546,30 @@ class PtychographyOptimizer:
             def f(ptycho):
                 return -np.std(np.angle(ptycho.object_cropped))
 
+        elif error_metric == "entropy":
+
+            def f(ptycho):
+                array = np.abs(ptycho.object_cropped)
+                normalized_array = (array - np.min(array)) / np.ptp(array)
+                # gx = normalized_array[..., 1:, :] - normalized_array[..., -1:, :]
+                # gy = normalized_array[..., :, 1:] - normalized_array[..., :, -1:]
+                gx, gy = np.gradient(normalized_array, axis=(-2, -1))
+                ghist, _, _ = np.histogram2d(gx.ravel(), gy.ravel(), bins=array.shape)
+                ghist = ghist[ghist > 0] / array.size
+                S = np.sum(ghist * np.log2(ghist))
+                return S
+
         elif error_metric == "entropy-phase":
 
             def f(ptycho):
-                obj = np.angle(ptycho.object_cropped)
-                gx, gy = np.gradient(obj)
-                ghist, _, _ = np.histogram2d(
-                    gx.ravel(), gy.ravel(), bins=obj.shape, density=True
-                )
-                nz = ghist > 0
-                S = np.sum(ghist[nz] * np.log2(ghist[nz]))
+                array = np.angle(ptycho.object_cropped)
+                normalized_array = (array - np.min(array)) / np.ptp(array)
+                # gx = normalized_array[..., 1:, :] - normalized_array[..., -1:, :]
+                # gy = normalized_array[..., :, 1:] - normalized_array[..., :, -1:]
+                gx, gy = np.gradient(normalized_array, axis=(-2, -1))
+                ghist, _, _ = np.histogram2d(gx.ravel(), gy.ravel(), bins=array.shape)
+                ghist = ghist[ghist > 0] / array.size
+                S = np.sum(ghist * np.log2(ghist))
                 return S
 
         else:

--- a/py4DSTEM/process/phase/parameter_optimize.py
+++ b/py4DSTEM/process/phase/parameter_optimize.py
@@ -458,7 +458,7 @@ class PtychographyOptimizer:
         return static_args, optimization_args
 
     def _get_scan_positions(self, affine_transform, dataset):
-        scan_positions = self._init_static_args.pop("initial_scan_positions", None)
+        scan_positions = self._init_static_args.get("initial_scan_positions", None)
         if scan_positions is None:
             R_pixel_size = dataset.calibration.get_R_pixel_size()
             x, y = (

--- a/py4DSTEM/process/phase/phase_base_class.py
+++ b/py4DSTEM/process/phase/phase_base_class.py
@@ -1551,6 +1551,7 @@ class PtychographicReconstruction(PhaseReconstruction):
             "semiangle_cutoff": self._semiangle_cutoff,
             "rolloff": self._rolloff,
             "object_padding_px": self._object_padding_px,
+            "object_fov_ang": self._object_fov_ang,
             "object_type": self._object_type,
             "verbose": self._verbose,
             "device": self._device,

--- a/py4DSTEM/process/phase/phase_base_class.py
+++ b/py4DSTEM/process/phase/phase_base_class.py
@@ -1351,6 +1351,7 @@ class PhaseReconstruction(Custom):
         com_fitted_y,
         positions_mask,
         crop_patterns,
+        in_place_datacube_modification,
     ):
         """
         Fix diffraction intensities CoM, shift to origin, and take square root
@@ -1363,78 +1364,67 @@ class PhaseReconstruction(Custom):
             Best fit horizontal center of mass gradient
         com_fitted_y: (Rx,Ry) xp.ndarray
             Best fit vertical center of mass gradient
-        positions_mask: np.ndarray, optional
+        positions_mask: np.ndarray
             Boolean real space mask to select positions in datacube to skip for reconstruction
         crop_patterns: bool
-            if True, crop patterns to avoid wrap around of patterns
-            when centering
+            If True, patterns are cropped to avoid wrap around of patterns
+        in_place_datacube_modification: bool
+            If True, the diffraction intensities are modified in-place
 
         Returns
         -------
-        amplitudes: (Rx * Ry, Sx, Sy) np.ndarray
+        diffraction_intensities: (Rx * Ry, Sx, Sy) np.ndarray
             Flat array of normalized diffraction amplitudes
         mean_intensity: float
             Mean intensity value
+        crop_mask
+            Mask to crop diffraction patterns with
         """
 
         # explicit read-only self attributes up-front
         asnumpy = self._asnumpy
 
         mean_intensity = 0
-
-        diffraction_intensities = asnumpy(diffraction_intensities)
         com_fitted_x = asnumpy(com_fitted_x)
         com_fitted_y = asnumpy(com_fitted_y)
 
-        if positions_mask is not None:
-            number_of_patterns = np.count_nonzero(positions_mask.ravel())
+        if in_place_datacube_modification:
+            diff_intensities = diffraction_intensities
         else:
-            number_of_patterns = np.prod(diffraction_intensities.shape[:2])
+            diff_intensities = diffraction_intensities.copy()
 
         # Aggressive cropping for when off-centered high scattering angle data was recorded
         if crop_patterns:
             crop_x = int(
                 np.minimum(
-                    diffraction_intensities.shape[2] - com_fitted_x.max(),
+                    diff_intensities.shape[2] - com_fitted_x.max(),
                     com_fitted_x.min(),
                 )
             )
             crop_y = int(
                 np.minimum(
-                    diffraction_intensities.shape[3] - com_fitted_y.max(),
+                    diff_intensities.shape[3] - com_fitted_y.max(),
                     com_fitted_y.min(),
                 )
             )
 
             crop_w = np.minimum(crop_y, crop_x)
-            diffraction_intensities_shape_crop = (crop_w * 2, crop_w * 2)
-            amplitudes = np.zeros(
-                (
-                    number_of_patterns,
-                    crop_w * 2,
-                    crop_w * 2,
-                ),
-                dtype=np.float32,
-            )
 
-            crop_mask = np.zeros(diffraction_intensities.shape[-2:], dtype=np.bool_)
+            crop_mask = np.zeros(diff_intensities.shape[-2:], dtype="bool")
             crop_mask[:crop_w, :crop_w] = True
             crop_mask[-crop_w:, :crop_w] = True
             crop_mask[:crop_w:, -crop_w:] = True
             crop_mask[-crop_w:, -crop_w:] = True
 
+            crop_mask_shape = (crop_w * 2, crop_w * 2)
+
         else:
             crop_mask = None
-            diffraction_intensities_shape_crop = diffraction_intensities.shape[-2:]
-            amplitudes = np.zeros(
-                (number_of_patterns,) + diffraction_intensities_shape_crop,
-                dtype=np.float32,
-            )
+            crop_mask_shape = diff_intensities.shape[-2:]
 
-        counter = 0
         for rx, ry in tqdmnd(
-            diffraction_intensities.shape[0],
-            diffraction_intensities.shape[1],
+            diff_intensities.shape[0],
+            diff_intensities.shape[1],
             desc="Normalizing amplitudes",
             unit="probe position",
             disable=not self._verbose,
@@ -1442,28 +1432,32 @@ class PhaseReconstruction(Custom):
             if positions_mask is not None:
                 if not positions_mask[rx, ry]:
                     continue
+
             intensities = get_shifted_ar(
-                diffraction_intensities[rx, ry],
+                diff_intensities[rx, ry],
                 -com_fitted_x[rx, ry],
                 -com_fitted_y[rx, ry],
                 bilinear=True,
                 device="cpu",
             )
 
-            if crop_patterns:
-                intensities = intensities[crop_mask].reshape(
-                    diffraction_intensities_shape_crop
-                )
-
             mean_intensity += np.sum(intensities)
-            amplitudes[counter] = np.sqrt(np.maximum(intensities, 0))
-            counter += 1
+            diff_intensities[rx, ry] = np.sqrt(np.maximum(intensities, 0))
 
-        mean_intensity /= amplitudes.shape[0]
+        if positions_mask is not None:
+            diff_intensities = diff_intensities[positions_mask]
+        else:
+            qx, qy = diff_intensities.shape[-2:]
+            diff_intensities = diff_intensities.reshape((-1, qx, qy))
 
-        self._diffraction_intensities_shape_crop = diffraction_intensities_shape_crop
+        if crop_patterns:
+            diff_intensities = diff_intensities[:, crop_mask].reshape(
+                (-1,) + crop_mask_shape
+            )
 
-        return amplitudes, mean_intensity, crop_mask
+        mean_intensity /= diff_intensities.shape[0]
+
+        return diff_intensities, mean_intensity, crop_mask, crop_mask_shape
 
     def show_complex_CoM(
         self,

--- a/py4DSTEM/process/phase/ptychographic_methods.py
+++ b/py4DSTEM/process/phase/ptychographic_methods.py
@@ -1022,6 +1022,7 @@ class ProbeMethodsMixin:
         device = self._device
 
         crop_mask = self._crop_mask
+        crop_mask_shape = self._crop_mask_shape
         region_of_interest_shape = self._region_of_interest_shape
         sampling = self.sampling
         energy = self._energy
@@ -1049,7 +1050,7 @@ class ProbeMethodsMixin:
 
                 if crop_patterns:
                     vacuum_probe_intensity = vacuum_probe_intensity[crop_mask].reshape(
-                        self._diffraction_intensities_shape_crop
+                        crop_mask_shape
                     )
 
                 sx, sy = vacuum_probe_intensity.shape

--- a/py4DSTEM/process/phase/ptychographic_tomography.py
+++ b/py4DSTEM/process/phase/ptychographic_tomography.py
@@ -219,6 +219,7 @@ class PtychographicTomography(
         padded_diffraction_intensities_shape: Tuple[int, int] = None,
         region_of_interest_shape: Tuple[int, int] = None,
         dp_mask: np.ndarray = None,
+        in_place_datacube_modification: bool = False,
         fit_function: str = "plane",
         plot_probe_overlaps: bool = True,
         rotation_real_space_degrees: float = None,
@@ -261,6 +262,9 @@ class PtychographicTomography(
             at the diffraction plane to allow comparison with experimental data
         dp_mask: ndarray, optional
             Mask for datacube intensities (Qx,Qy)
+        in_place_datacube_modification: bool, optional
+            If True, the datacube will be preprocessed in-place. Note this is not possible
+            when either crop_patterns or positions_mask are used.
         fit_function: str, optional
             2D fitting function for CoM fitting. One of 'plane','parabola','bezier_two'
         plot_probe_overlaps: bool, optional
@@ -478,6 +482,7 @@ class PtychographicTomography(
                 amplitudes,
                 mean_diffraction_intensity_temp,
                 self._crop_mask,
+                self._crop_mask_shape,
             ) = self._normalize_diffraction_intensities(
                 intensities,
                 com_fitted_x,

--- a/py4DSTEM/process/phase/singleslice_ptychography.py
+++ b/py4DSTEM/process/phase/singleslice_ptychography.py
@@ -195,6 +195,7 @@ class SingleslicePtychography(
         padded_diffraction_intensities_shape: Tuple[int, int] = None,
         region_of_interest_shape: Tuple[int, int] = None,
         dp_mask: np.ndarray = None,
+        in_place_datacube_modification: bool = False,
         fit_function: str = "plane",
         plot_center_of_mass: str = "default",
         plot_rotation: bool = True,
@@ -236,6 +237,9 @@ class SingleslicePtychography(
             at the diffraction plane to allow comparison with experimental data
         dp_mask: ndarray, optional
             Mask for datacube intensities (Qx,Qy)
+        in_place_datacube_modification: bool, optional
+            If True, the datacube will be preprocessed in-place. Note this is not possible
+            when either crop_patterns or positions_mask are used.
         fit_function: str, optional
             2D fitting function for CoM fitting. One of 'plane','parabola','bezier_two'
         plot_center_of_mass: str, optional
@@ -405,17 +409,21 @@ class SingleslicePtychography(
             self._amplitudes,
             self._mean_diffraction_intensity,
             self._crop_mask,
+            self._crop_mask_shape,
         ) = self._normalize_diffraction_intensities(
             _intensities,
             self._com_fitted_x,
             self._com_fitted_y,
             self._positions_mask,
             crop_patterns,
+            in_place_datacube_modification,
         )
 
         # explicitly transfer arrays to storage
+        if not in_place_datacube_modification:
+            del _intensities
+
         self._amplitudes = copy_to_device(self._amplitudes, storage)
-        del _intensities
 
         self._num_diffraction_patterns = self._amplitudes.shape[0]
         self._amplitudes_shape = np.array(self._amplitudes.shape[-2:])

--- a/py4DSTEM/process/phase/xray_magnetic_ptychography.py
+++ b/py4DSTEM/process/phase/xray_magnetic_ptychography.py
@@ -560,6 +560,7 @@ class XRayMagneticPtychography(
                 com_fitted_y,
                 self._positions_mask[index],
                 crop_patterns,
+                in_place_datacube_modification,
             )
 
             self._mean_diffraction_intensity.append(mean_diffraction_intensity_temp)

--- a/py4DSTEM/process/phase/xray_magnetic_ptychography.py
+++ b/py4DSTEM/process/phase/xray_magnetic_ptychography.py
@@ -206,6 +206,7 @@ class XRayMagneticPtychography(
         padded_diffraction_intensities_shape: Tuple[int, int] = None,
         region_of_interest_shape: Tuple[int, int] = None,
         dp_mask: np.ndarray = None,
+        in_place_datacube_modification: bool = False,
         fit_function: str = "plane",
         plot_rotation: bool = True,
         maximize_divergence: bool = False,
@@ -257,6 +258,9 @@ class XRayMagneticPtychography(
             at the diffraction plane to allow comparison with experimental data
         dp_mask: ndarray, optional
             Mask for datacube intensities (Qx,Qy)
+        in_place_datacube_modification: bool, optional
+            If True, the datacube will be preprocessed in-place. Note this is not possible
+            when either crop_patterns or positions_mask are used.
         fit_function: str, optional
             2D fitting function for CoM fitting. One of 'plane','parabola','bezier_two'
         plot_rotation: bool, optional
@@ -549,6 +553,7 @@ class XRayMagneticPtychography(
                 amplitudes,
                 mean_diffraction_intensity_temp,
                 self._crop_mask,
+                self._crop_mask_shape,
             ) = self._normalize_diffraction_intensities(
                 intensities,
                 com_fitted_x,

--- a/py4DSTEM/process/phase/xray_magnetic_ptychography.py
+++ b/py4DSTEM/process/phase/xray_magnetic_ptychography.py
@@ -375,10 +375,6 @@ class XRayMagneticPtychography(
                 f"datacube must be the same length as magnetic_contribution_sign, not length {len(self._datacube)}."
             )
 
-        dc_shapes = [dc.shape for dc in self._datacube]
-        if dc_shapes.count(dc_shapes[0]) != self._num_measurements:
-            raise ValueError("datacube intensities must be the same size.")
-
         if self._positions_mask is not None:
             self._positions_mask = np.asarray(self._positions_mask, dtype="bool")
 


### PR DESCRIPTION
Various quality of life improvements for the `phase` module. Namely:
- Pixel dimensions invariant BO metrics
- Optional in-place preprocessing of datacube
- `max_batch_size` option in parallax `preprocess` and `reconstruct` (only useful for shifting cross-correlated VBFs)
- `aligned_bf_image_guess` option in parallax `preprocess` to initialize cross-correlation with
- new `guess_common_aberrations` function which accepts microscope geometry parameters (rotation/transpose), as-well as common aberrations (defocus, stig, coma, spherical), and computes the analytical BF shifts -- using them to compute the aligned (and optionally upsampled) BF image
  - note this returns a static figure, but is easy to make into a widget inside a jupyter notebook
  ```python
  import ipywidgets
  
  def widget_wrapper(rotation_angle_deg, transpose, defocus, upsampling_factor):
      """ wrapper to only pass interactive sliders of interest """
      return parallax.guess_common_aberrations(
          rotation_angle_deg = rotation_angle_deg,
          transpose = transpose,
          defocus = defocus,
          kde_upsample_factor = upsampling_factor,
      )
      
  ipywidgets.interact(
      widget_wrapper,
      rotation_angle_deg = -15,
      transpose = False,
      defocus = 1.5e4,
      upsampling_factor = 1,
  );
  ```