### PR TITLE
Update polar_analysis.py

### DIFF
--- a/py4DSTEM/process/polar/polar_analysis.py
+++ b/py4DSTEM/process/polar/polar_analysis.py
@@ -526,8 +526,8 @@ def plot_background_fits(
     ax.set_ylabel("I(k) and Background Fit Estimates")
     ax.set_ylim(
         (
-            np.min(self.radial_mean[self.radial_mean > 0]) * 0.8,
-            np.max(self.radial_mean * self.Sk_mask) * 1.25,
+            np.min(Ik[Ik > 0]) * 0.8,
+            np.max(Ik * self.Sk_mask) * 1.25,
         )
     )
     ax.set_yscale("log")

--- a/py4DSTEM/process/polar/polar_analysis.py
+++ b/py4DSTEM/process/polar/polar_analysis.py
@@ -343,8 +343,8 @@ def calculate_pair_dist_function(
     sub_fit = k >= k_min
 
     # initial guesses for background coefs
-    const_bg = np.min(self.radial_mean) / int_mean
-    int0 = np.median(self.radial_mean) / int_mean - const_bg
+    const_bg = np.min(Ik) / int_mean
+    int0 = np.median(Ik) / int_mean - const_bg
     sigma0 = np.mean(k)
     coefs = [const_bg, int0, sigma0, int0, sigma0]
     lb = [0, 0, 0, 0, 0]

--- a/py4DSTEM/process/polar/polar_analysis.py
+++ b/py4DSTEM/process/polar/polar_analysis.py
@@ -335,9 +335,9 @@ def calculate_pair_dist_function(
         Ik = self.radial_mean
     elif RxRy != None and hxwy == None:
         Ik = self.radial_all[RxRy[0], RxRy[1]]
-    elif RxRy != None and hxhy != None:
+    elif RxRy != None and hxwy != None:
         Ik = self.radial_all[
-            RxRy[0] : RxRy[0] + hxhy[0], RxRy[1] : RxRy[1] + hxwy[1]
+            RxRy[0] : RxRy[0] + hxwy[0], RxRy[1] : RxRy[1] + hxwy[1]
         ].mean(axis=(0, 1))
     int_mean = np.mean(Ik)
     sub_fit = k >= k_min


### PR DESCRIPTION
Updated to allow calculation of rdfs from single points or small areas

Main point was to replace calls to self.radial_mean with defining Ik either as self.radial_mean or areas selected/averaged from self.radial_all

Some minor updates were also needed in plot_background_fits

Some doc strings added

The one weakness in my code is that the rdf from the sub area is then attached to self as representative of whole dataset.  This doesn't worry me for now.  If I want a different sub-area, I can recalculate.  But you may wish to do point by point calculation over entire dataset at some point.