### PR TITLE
Fix for show_complex interaction with scalebar dict

### DIFF
--- a/py4DSTEM/visualize/show.py
+++ b/py4DSTEM/visualize/show.py
@@ -186,7 +186,7 @@ def show(
         and
 
             >>> show(dp, calibration=calibration, scalebar={'length':0.5,'width':2,
-                                                       'position':'ul','label':True'})
+                                                       'position':'ul','label':True})
 
         will display a more customized scalebar.
 
@@ -316,7 +316,7 @@ def show(
         if returnfig==False (default), the figure is plotted and nothing is returned.
         if returnfig==True, return the figure and the axis.
     """
-    if scalebar is True:
+    if scalebar is True or scalebar is None:
         scalebar = {}
 
     # Alias dep
@@ -428,7 +428,7 @@ def show(
             er = ".calibration attribute must be a Calibration instance"
             assert isinstance(cal, Calibration), er
             if isinstance(ar, DiffractionSlice):
-                scalebar = {
+                defaultscalebar = {
                     "Nx": ar.data.shape[0],
                     "Ny": ar.data.shape[1],
                     "pixelsize": cal.get_Q_pixel_size(),
@@ -436,10 +436,13 @@ def show(
                     "space": "Q",
                     "position": "br",
                 }
+                for key, value in defaultscalebar.items():
+                    if key not in scalebar.keys():
+                        scalebar[key] = value
                 pixelsize = cal.get_Q_pixel_size()
                 pixelunits = cal.get_Q_pixel_units()
             elif isinstance(ar, RealSlice):
-                scalebar = {
+                defaultscalebar = {
                     "Nx": ar.data.shape[0],
                     "Ny": ar.data.shape[1],
                     "pixelsize": cal.get_R_pixel_size(),
@@ -447,6 +450,9 @@ def show(
                     "space": "Q",
                     "position": "br",
                 }
+                for key, value in defaultscalebar.items():
+                    if key not in scalebar.keys():
+                        scalebar[key] = value
                 pixelsize = cal.get_R_pixel_size()
                 pixelunits = cal.get_R_pixel_units()
         # get the data

--- a/py4DSTEM/visualize/vis_special.py
+++ b/py4DSTEM/visualize/vis_special.py
@@ -845,7 +845,7 @@ def show_complex(
             add_scalebar(ax[0, 0], scalebar)
     else:
         figsize = kwargs.pop("axsize", None)
-        figsize = kwargs.pop("figsize", figsize)
+        figsize = kwargs.pop("figsize", (5, 5))
 
         fig, ax = show(
             rgb,


### PR DESCRIPTION
See #673 and #689. `show_complex` incorrectly assigned None to `figsize` when popping it from the kwargs resulting in broken plotting due to interaction with `scalebar`, it now assigns a default figsize as is typical for other show type functions. I did not find the same issue in the other show functions. @smribet please let me know if you have a case where this is still broken.