### PR TITLE
Update digital_dark_field.py

### DIFF
--- a/py4DSTEM/process/diffraction/digital_dark_field.py
+++ b/py4DSTEM/process/diffraction/digital_dark_field.py
@@ -482,7 +482,7 @@ def DDFimage(points_array, aperture_positions, Rshape=None, tol=1):
         aperture_position = aperture_positions[aperture_index]
         intensities = np.vstack(
             (
-                points_array[:, 2:].T,
+                points_array[:, 2:5].T,
                 pointlist_differences(aperture_position, points_array),
             )
         ).T


### PR DESCRIPTION
Fixed one error that causes incorrect calculation of DDFimage if the pointsarray has 7 columns, by simply changing 2: to 2:5 in the calculation