### PR TITLE
Update WK_scattering_factors.py

### DIFF
--- a/py4DSTEM/process/diffraction/WK_scattering_factors.py
+++ b/py4DSTEM/process/diffraction/WK_scattering_factors.py
@@ -174,14 +174,9 @@ def compute_WK_factor(
         B1 = B / (4.0 * np.pi) ** 2
 
         for jj in range(4):
-            Fphon += (
-                A1[jj]
-                * A1[jj]
-                * (DWF * RI1(B1[jj], B1[jj], G) - RI2(B1[jj], B1[jj], G, UL))
-            )
             for ii in range(jj + 1):
                 Fphon += (
-                    2.0
+                    (2.0 if jj != ii else 1.0)
                     * A1[jj]
                     * A1[ii]
                     * (DWF * RI1(B1[ii], B1[jj], G) - RI2(B1[ii], B1[jj], G, UL))


### PR DESCRIPTION
Relevant WK computation in others.f90 in Prof. Marc De Graef's EMsoft reads: 

```
DO J=1,4
  FPHON = FPHON + A1(J)*A1(J)*(DEWA * RI1(B1(J),B1(J),G) - RI2(B1(J),B1(J),G,UL))
  DO I=1,J-1
   FPHON = FPHON + 2.*A1(J)*A1(I)*(DEWA * RI1(B1(I),B1(J),G)-RI2(B1(I),B1(J),G,UL))
```

When J=1:
The inner loop condition is DO I=1,0 (since J-1 = 0). In Fortran, when the upper bound is less than the lower bound, the loop is not executed at all. So for J=1, only the first FPHON calculation happens, the inner loop is skipped. In the current py4DSTEM code, the inner loop is executed for ii = jj = 0 making the diagonal computed a second time with a factor of 2.0, for an overall prefactor of 3.0 instead of 1.0 when ii equals jj. If I am missing something and this python code has already been verified against others.f90, then completely ignore this.