### PR TITLE
Update WK_scattering_factors.py

### DIFF
--- a/py4DSTEM/process/diffraction/WK_scattering_factors.py
+++ b/py4DSTEM/process/diffraction/WK_scattering_factors.py
@@ -83,7 +83,7 @@ def compute_WK_factor(
     WK = np.zeros_like(S)
     for i in range(4):
         argu = B[i] * S**2
-        sub = argu < 1.0
+        sub = argu < 0.1
         WK[sub] += A[i] * B[i] * (1.0 - 0.5 * argu[sub])
         sub = np.logical_and(argu >= 1.0, argu <= 20.0)
         WK[sub] += A[i] * (1.0 - np.exp(-argu[sub])) / S[sub] ** 2


### PR DESCRIPTION
Presumed typo changed the cut-off for WEKO argument from the correct value 0.1 to the incorrect value 1.0. This returns the value to 0.1 to match WK's F77 implementation ported to F90 by MDG:

https://github.com/EMsoft-org/EMsoftOO/blob/develop/Source/EMsoftOOLib/mod_others.f90#L191

"IF (ARGU .LT. .1) THEN"

0.1 shows no artifacts in the real part (plot from my private PyTorch repo):
![wk_scatter_with_0 1_no_artifacts](https://github.com/user-attachments/assets/6784779c-5a6e-4b1b-b1b6-b140de55b7a0)

and 1.0 shows clear artifacts in the real part (plot from my private PyTorch repo)
![wk_scatter_with_1 0_artifacts](https://github.com/user-attachments/assets/3363670c-4e9d-4f15-a5a4-ca554fa32ef4)
