### PR TITLE
DDF patch 11

### DIFF
--- a/py4DSTEM/process/diffraction/digital_dark_field.py
+++ b/py4DSTEM/process/diffraction/digital_dark_field.py
@@ -550,16 +550,8 @@ def DDF_radial_image(points_array_w_rphi, radius, Rshape, tol=1):
 
     radialimage = np.zeros(shape=Rshape)
 
-    for i in range(Rshape[0]):
-        for j in range(Rshape[1]):
-            radialimage[i, j] = np.where(
-                np.logical_and(
-                    radial_filtered_points_array[:, 3] == i,
-                    radial_filtered_points_array[:, 4] == j,
-                ),
-                radial_filtered_points_array[:, 2],
-                0,
-            ).sum()
+    for line in radial_filtered_points_array:
+        radialimage[int(line[3]), int(line[4])] += line[2]
 
     return radialimage
 
@@ -612,14 +604,7 @@ def DDFradialazimuthimage(points_array_w_rphi, radius, phi0, phi1, Rshape, tol=1
     )
     radiusazimuthimage = np.zeros(shape=Rshape)
 
-    for i in range(Rshape[0]):
-        for j in range(Rshape[1]):
-            radiusazimuthimage[i, j] = np.where(
-                np.logical_and(
-                    rphi_filtered_points_array[:, 3] == i,
-                    rphi_filtered_points_array[:, 4] == j,
-                ),
-                rphi_filtered_points_array[:, 2],
-                0,
-            ).sum()
+    for line in rphi_filtered_points_array:
+        radiusazimuthimage[int(line[3]), int(line[4])] += line[2]
+
     return radiusazimuthimage

--- a/py4DSTEM/visualize/show.py
+++ b/py4DSTEM/visualize/show.py
@@ -267,8 +267,8 @@ def show(
                 * 'centered': The vmin/vmax values are set to ``c -/+ m``, where by default
                   'c' is zero and m is the max(abs(ar-c), or the two params can be user
                   specified using the kwargs vmin/vmax -> c/m.
-        vmin (number): min intensity, behavior depends on clipvals
-        vmax (number): max intensity, behavior depends on clipvals
+        vmin (number): min intensity, behavior depends on intensity_range
+        vmax (number): max intensity, behavior depends on intensity_range
         min,max: alias' for vmin,vmax, throws deprecation warning
         power (number): specifies the scaling power
         power_offset (bool): If true, image has min value subtracted before power scaling


### PR DESCRIPTION
I found out when processing large datasets that the DDFradialimage and DDFradialazimuthimage code is as slow as an old dog.  I then figured out that I had done the coding really stupidly, rebuilt it and it's now very fast.

Please approve this, along with the minor corrections to "show"