### PR TITLE
Fix pyparsing deprecation flood without touching matplotlib

### DIFF
--- a/py4DSTEM/__init__.py
+++ b/py4DSTEM/__init__.py
@@ -1,6 +1,29 @@
 from py4DSTEM.version import __version__
 from emdfile import tqdmnd
 
+# matplotlib < 3.11 mathtext calls pyparsing's deprecated camelCase API
+# (parseString / parseAll / resetCache) once per rendered math label, which
+# floods plotting output with deprecation messages under pyparsing >= 3.3.
+# Rebind those compatibility aliases to call the snake_case API directly with
+# the renamed arguments, so the deprecated code paths are never executed.
+# Upgrading matplotlib instead is not an option in hosted notebooks (Colab
+# preimports matplotlib, and a mid-session upgrade leaves a broken half-old,
+# half-new install). Skipped entirely on matplotlib >= 3.11.
+import matplotlib as _matplotlib
+import pyparsing as _pyparsing
+
+if getattr(_matplotlib, "__version_info__", (99,)) < (3, 11) and hasattr(
+    _pyparsing.ParserElement, "parse_string"
+):
+
+    def _parse_string_compat(self, instring, parseAll=False, *, parse_all=None):
+        return self.parse_string(
+            instring, parse_all=parseAll if parse_all is None else parse_all
+        )
+
+    _pyparsing.ParserElement.parseString = _parse_string_compat
+    _pyparsing.ParserElement.resetCache = classmethod(lambda cls: cls.reset_cache())
+
 from importlib.metadata import packages_distributions
 
 is_package_lite = "py4DSTEM-lite" in packages_distributions()["py4DSTEM"]

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,7 @@ setup(
         "h5py >= 3.2.0",
         "hdf5plugin >= 4.1.3",
         "ncempy >= 1.8.1",
-        # matplotlib < 3.11 calls pyparsing's deprecated camelCase API from
-        # mathtext, which floods plotting output with deprecation warnings
-        # under pyparsing >= 3.3; require 3.11 wherever python allows it
-        "matplotlib >= 3.2.2; python_version < '3.11'",
-        "matplotlib >= 3.11; python_version >= '3.11'",
+        "matplotlib >= 3.2.2",
         "scikit-image >= 0.17.2",
         "scikit-learn >= 0.23.2",
         "scikit-optimize >= 0.9.0",


### PR DESCRIPTION
Reverts the matplotlib >= 3.11 requirement: hosted notebook runtimes
(Colab) preimport matplotlib at kernel start, so a mid-session pip
upgrade leaves a broken half-old, half-new install (new
mpl_toolkits.axes_grid1 loaded lazily against the old in-memory
matplotlib._api).

Instead, rebind pyparsing's deprecated camelCase compatibility aliases
(parseString / resetCache, including the parseAll argument) to call the
snake_case API directly with the renamed arguments. matplotlib < 3.11
mathtext calls those aliases once per rendered math label, which floods
plotting output under pyparsing >= 3.3; with the rebind the deprecated
code paths are never executed, in any session, with no install changes.
Verified the rebound aliases give identical parse results and
exceptions, emit no warnings, and are skipped on matplotlib >= 3.11.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
